### PR TITLE
Replacing literal strings with constant strings

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -9,8 +9,10 @@ var bunyan = require('bunyan');
 var uuid = require('uuid');
 var async = require('async');
 
+var Constants = require("./constants/constants.js");
+
 var SATOSHI_FACTOR = Math.pow(10,8);
-var STATIC_STATES = ['idle', 'networkDown', 'balanceLow', 'unpaired'];
+var STATIC_STATES = [Constants.IDLE, Constants.NETWORK_DOWN, Constants.BALANCE_LOW, Constants.UNPAIRED];
 var TRANSACTION_STATES = ['acceptingFirstBill', 'billInserted', 'billRead','acceptingBills',
   'bitcoinsSent', 'completed', 'goodbye'];
 var POWER_DOWN_STATES = TRANSACTION_STATES.concat('powerDown');
@@ -200,7 +202,7 @@ Brain.prototype.checkWifiStatus = function checkWifiStatus() {
 Brain.prototype._initTraderEvents = function _initTraderEvents() {
   var self = this;
   this.trader.on('pollUpdate', function() { self._pollUpdate(); });
-  this.trader.on('networkDown', function() { self._networkDown(); });
+  this.trader.on(Constants.NETWORK_DOWN, function() { self._networkDown(); });
   this.trader.on('networkUp', function() { self._networkUp(); });
   this.trader.on('error', function(err) { console.log(err.stack); });
   this.trader.on('unpair', function () { self._unpair(); });
@@ -251,12 +253,12 @@ Brain.prototype._init = function init() {
 };
 
 Brain.prototype._updateConfig = function _updateConfig(config) {
-  if(this.state === 'idle') {
+  if(this.state === Constants.IDLE) {
     this.rootConfig = config;
     console.log('setting new live config');
   } else {
     console.log('waiting for idle');
-    this.once('idle', function() {
+    this.once(Constants.IDLE, function() {
       console.log('setting new live config');
       this.rootConfig = config;
     });
@@ -276,7 +278,7 @@ Brain.prototype._setUpN7 = function _setUpN7() {
 };
 
 Brain.prototype._connectedBrowser = function _connectedBrowser() {
-//  TODO: have to work on this: console.assert(this.state === 'idle');
+//  TODO: have to work on this: console.assert(this.state === Constants.IDLE);
   console.log('connected to browser');
 
   var rec = {
@@ -470,8 +472,8 @@ Brain.prototype._wifiConnected = function _wifiConnected() {
 };
 
 Brain.prototype._unpaired = function _unpaired() {
-  this._setState('unpaired');
-  this.browser.send({action: 'unpaired'});
+  this._setState(Constants.UNPAIRED);
+  this.browser.send({action: Constants.UNPAIRED});
 };
 
 Brain.prototype._pairingScan = function _pairingScan() {
@@ -534,7 +536,7 @@ Brain.prototype._idle = function _idle() {
   this._setState('pendingIdle');
   if (this.networkDown) return this._networkDown();
   if (this.balanceLow) return this._balanceLow();
-  this._transitionState('idle', {localeInfo: this.localeInfo});
+  this._transitionState(Constants.IDLE, {localeInfo: this.localeInfo});
 };
 
 Brain.prototype._start = function _start() {
@@ -686,7 +688,7 @@ Brain.prototype._forceNetworkDown = function _forceNetworkDown() {
     return;
   }
 
-  if (this.hasConnected) this._transitionState('networkDown');
+  if (this.hasConnected) this._transitionState(Constants.NETWORK_DOWN);
 };
 
 Brain.prototype._networkUp = function _networkUp() {
@@ -694,20 +696,20 @@ Brain.prototype._networkUp = function _networkUp() {
   if (!this.billValidator.hasDenominations()) return;
 
   this.networkDown = false;
-  if (this.state === 'networkDown' || this.state === 'connecting' || this.state === 'wifiConnected')
+  if (this.state === Constants.NETWORK_DOWN || this.state === 'connecting' || this.state === 'wifiConnected')
     this._restart();
 };
 
 Brain.prototype._balanceLow = function _balanceLow() {
   this.balanceLow = true;
-  if (this.state === 'balanceLow') return;
+  if (this.state === Constants.BALANCE_LOW) return;
   if (_.contains(BILL_ACCEPTING_STATES, this.state)) {
     this.billValidator.disable();
     this.browser.send({sendOnly: 'lowBalance'});
     return;
   }
   if (_.contains(TRANSACTION_STATES, this.state)) return;
-  this._transitionState('balanceLow');
+  this._transitionState(Constants.BALANCE_LOW);
 };
 
 Brain.prototype._transitionState = function _transitionState(state, auxData) {
@@ -722,7 +724,7 @@ Brain.prototype._transitionState = function _transitionState(state, auxData) {
 
 Brain.prototype._balanceAdequate = function _balanceAdequate() {
   this.balanceLow = false;
-  if (this.state === 'balanceLow') this._restart();
+  if (this.state === Constants.BALANCE_LOW) this._restart();
 };
 
 Brain.prototype._bitcoinFractionalDigits =
@@ -884,7 +886,7 @@ Brain.prototype._billRejected = function _billRejected() {
   this.pending = null;
   var returnState = this.credit.fiat === 0 ?
       'acceptingFirstBill' : 'acceptingBills';
-  if (this.state !== 'balanceLow') this._setState(returnState);
+  if (this.state !== Constants.BALANCE_LOW) this._setState(returnState);
   var credit = this._uiCredit();
   if (!credit.fiat || credit.fiat === 0) credit = null;
   var response = {
@@ -913,7 +915,7 @@ Brain.prototype._billStandby = function _billStandby() {
 
 Brain.prototype._billJam = function _billJam() {
   // TODO FIX: special screen and state for this
-  this.browser.send({action: 'networkDown'});
+  this.browser.send({action: Constants.NETWORK_DOWN});
 };
 
 Brain.prototype._billsEnabled = function _billsEnabled(data) {
@@ -1209,9 +1211,9 @@ Brain.prototype._unpair = function _unpair() {
   console.log('Unpairing');
   self.trader.stop();
   self.pairing.unpair(function () {
-    console.log('Unpaired');
-    self._setState('unpaired');
-    self.browser.send({action: 'unpaired'});
+    console.log(Constants.UNPAIRED);
+    self._setState(Constants.UNPAIRED);
+    self.browser.send({action: Constants.UNPAIRED});
   });
 };
 

--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var constants = {};
+
+constants.IDLE = "idle";
+constants.NETWORK_DOWN = "networkDown";
+constants.BALANCE_LOW = "balanceLow";
+constants.UNPAIRED = "unpaired";


### PR DESCRIPTION
How would you feel about replacing the literal strings with constants?

I think it will make the code easier to understand, and to maintain.

I thought to do this because I ran across a difference in app.js, and brain.js. App.js uses the string 'scan_address' to refer to the section of HTML to display. It then tells brain.js to 'start', and then brain.js uses the string 'scanAddress' to indicate its state. There's no reason the two strings should be different; they can both use 'scan_address' and achieve the same effect.

I'm sure there are other similar cases.. all that would be avoided by using constants, among other benefits.

This pull request only changes a few strings to constants, to give an idea what I plan to do. If accepted, I will make the necessary changes elsewhere, too.
