### PR TITLE
Canary replace literal strings with constant strings

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -258,7 +258,7 @@ Brain.prototype._initWifiEvents = function _initWifiEvents() {
 
   this.wifi.on('scan', function(res) {
     self.wifis = res;
-    self.browser.send({wifiList: res});
+    self.browser().send({wifiList: res});
   });
 
   this.wifi.on('authenticationError', function(data) {
@@ -1442,7 +1442,7 @@ Brain.prototype._unpair = function _unpair() {
   self.pairing.unpair(function () {
     console.log('Unpaired');
     self._setState('unpaired');
-    self.browser.send({action: 'unpaired'});
+    self.browser().send({action: 'unpaired'});
   });
 };
 
@@ -1571,7 +1571,7 @@ Brain.prototype._cashOut = function _cashOut() {
   this.trader.cashOut(tx, function (err, bitcoinAddress) {
     if (err) self._idle();
     tx.toAddress = bitcoinAddress;
-    self.browser.send({depositInfo: tx});
+    self.browser().send({depositInfo: tx});
   });
 };
 

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -568,6 +568,18 @@ Brain.prototype._wifiConnected = function _wifiConnected() {
   this._connect();
 };
 
+Brain.prototype._unpair = function _unpair() {
+  var self = this;
+
+  console.log('Unpairing');
+  self.trader().stop();
+  self.pairing().unpair(function () {
+    console.log('Unpaired');
+    self._setState(State.UNPAIRED);
+    self.browser().send({action: State.UNPAIRED});
+  });
+};
+
 Brain.prototype._unpaired = function _unpaired() {
   this._setState(State.UNPAIRED);
   this.browser().send({action: State.UNPAIRED});
@@ -1443,18 +1455,6 @@ Brain.prototype._checkPower = function _checkPower() {
 
 Brain.prototype._logTx = function _logTx(rec, msg) {
   this.txLog.info(rec, msg);
-};
-
-Brain.prototype._unpair = function _unpair() {
-  var self = this;
-
-  console.log('Unpairing');
-  self.trader().stop();
-  self.pairing().unpair(function () {
-    console.log('Unpaired');
-    self._setState(State.UNPAIRED);
-    self.browser().send({action: State.UNPAIRED});
-  });
 };
 
 Brain.prototype._billValidatorErr = function _billValidatorErr(err) {

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -13,7 +13,7 @@ var State = require('./constants/state.js');
 
 var SATOSHI_FACTOR = 1e8;
 var PRICE_PRECISION = 5;
-var STATIC_STATES = [State.IDLE, State.PENDING_IDLE, 'dualIdle', State.NETWORK_DOWN,
+var STATIC_STATES = [State.IDLE, State.PENDING_IDLE, State.DUAL_IDLE, State.NETWORK_DOWN,
   'unpaired'];
 var BILL_ACCEPTING_STATES = ['billInserted', 'billRead', 'acceptingBills',
   'acceptingFirstBill'];
@@ -672,7 +672,7 @@ Brain.prototype._idleTwoWay = function _idleTwoWay() {
     cartridges: this.trader.cartridges,
     currency: this.trader.locale.currency
   }, function() {
-    self._transitionState('dualIdle',
+    self._transitionState(State.DUAL_IDLE,
       {localeInfo: localeInfo, cartridges: uiCartridges});
   });
 };

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -14,7 +14,7 @@ var State = require('./constants/state.js');
 var SATOSHI_FACTOR = 1e8;
 var PRICE_PRECISION = 5;
 var STATIC_STATES = [State.IDLE, State.PENDING_IDLE, State.DUAL_IDLE, State.NETWORK_DOWN,
-  'unpaired'];
+  State.UNPAIRED];
 var BILL_ACCEPTING_STATES = ['billInserted', 'billRead', 'acceptingBills',
   'acceptingFirstBill'];
 var INITIAL_STATE = State.START;
@@ -569,8 +569,8 @@ Brain.prototype._wifiConnected = function _wifiConnected() {
 };
 
 Brain.prototype._unpaired = function _unpaired() {
-  this._setState('unpaired');
-  this.browser().send({action: 'unpaired'});
+  this._setState(State.UNPAIRED);
+  this.browser().send({action: State.UNPAIRED});
 };
 
 Brain.prototype._pairingScan = function _pairingScan() {
@@ -1452,8 +1452,8 @@ Brain.prototype._unpair = function _unpair() {
   self.trader().stop();
   self.pairing().unpair(function () {
     console.log('Unpaired');
-    self._setState('unpaired');
-    self.browser().send({action: 'unpaired'});
+    self._setState(State.UNPAIRED);
+    self.browser().send({action: State.UNPAIRED});
   });
 };
 

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -73,12 +73,16 @@ var Brain = function(config) {
   traderConfig.certs = certs;
   if (config.http) traderConfig.protocol = 'http';
 
+  var trader = undefined;
+  
   if (config.mockTrader) {
-    this.trader = require('./mocks/trader')(traderConfig);
+    trader = require('./mocks/trader')(traderConfig);
   } else
-    this.trader = require('./trader')(traderConfig);
+    trader = require('./trader')(traderConfig);
+  
+  this.setTrader(trader);
 
-  this.idVerify = require('./compliance/id_verify').factory({trader : this.trader});
+  this.idVerify = require('./compliance/id_verify').factory({trader : trader});
 
   this.setBrowser(require('./browser')());
   this._setState(INITIAL_STATE);
@@ -210,12 +214,12 @@ Brain.prototype._startTrading = function _startTrading() {
     if (err) return self._billValidatorErr(err);
 
     console.log('Bill validator connected.');
-    self.trader.init(self.pairing.connectionInfo());
+    self.trader().init(self.pairing.connectionInfo());
 
     // We want to wait until heavy CPU heavy certification generation is done
     self.billValidator.monitorHeartbeat();
 
-    self.trader.run();
+    self.trader().run();
     self._idle();
   });
 };
@@ -270,14 +274,16 @@ Brain.prototype._initWifiEvents = function _initWifiEvents() {
 
 Brain.prototype._initTraderEvents = function _initTraderEvents() {
   var self = this;
-  this.trader.on(State.POLL_UPDATE, function() { self._pollUpdate(); });
-  this.trader.on(State.NETWORK_DOWN, function() { self._networkDown(); });
-  this.trader.on('networkUp', function() { self._networkUp(); });
-  this.trader.on('dispenseUpdate', function(status) {
+  var trader = this.trader();
+  
+  trader.on(State.POLL_UPDATE, function() { self._pollUpdate(); });
+  trader.on(State.NETWORK_DOWN, function() { self._networkDown(); });
+  trader.on('networkUp', function() { self._networkUp(); });
+  trader.on('dispenseUpdate', function(status) {
     self._dispenseUpdate(status);
   });
-  this.trader.on('error', function(err) { console.log(err.stack); });
-  this.trader.on('unpair', function () { self._unpair(); });
+  trader.on('error', function(err) { console.log(err.stack); });
+  trader.on('unpair', function () { self._unpair(); });
 };
 
 Brain.prototype._initBrowserEvents = function _initBrowserEvents() {
@@ -353,8 +359,8 @@ Brain.prototype._connectedBrowser = function _connectedBrowser() {
     action: this.state,
     localeInfo: this.localeInfo,
     currency: this.currency,
-    exchangeRate: this._exchangeRateRec(this.trader.exchangeRate),
-    fiatExchangeRate: this.trader.fiatExchangeRate,
+    exchangeRate: this._exchangeRateRec(this.trader().exchangeRate),
+    fiatExchangeRate: this.trader().fiatExchangeRate,
     cartridges: this.uiCartridges
   };
 
@@ -586,7 +592,7 @@ Brain.prototype._pair = function _pair(json) {
   this._transitionState('pairing');
   this.pairing.pair(json, function (err, connectionInfo) {
     if (err) return self._pairingError(err);
-    self.trader.pair(connectionInfo);
+    self.trader().pair(connectionInfo);
     self._idle();
   });
 };
@@ -603,14 +609,14 @@ Brain.prototype._isTestMode = function _isTestMode() {
 Brain.prototype._testMode = function _testMode() {
   var self = this;
   this.testModeOn = true;
-  this.traderOld = this.trader;
-  this.trader.removeAllListeners();
-  this.trader = require('./mocks/trader')();
+  this.traderOld = this.trader();
+  this.trader().removeAllListeners();
+  this.setTrader(require('./mocks/trader')());
   this._initTraderEvents();
   this.pairing._connectionInfo = {};
   this.networkDown = false;
   this.getBillValidator().run(function () {
-    self.trader.run();
+	  self.trader().run();
     self._idle();
   });
 };
@@ -620,8 +626,8 @@ Brain.prototype._testModeOff = function _testModeOff() {
   this.getBillValidator().close(function() {
     self.testModeOn = false;
     self.pairing._connectionInfo = null;
-    self.trader.removeAllListeners();
-    self.trader = self.traderOld;
+    self.trader().removeAllListeners();
+    self.setTrader(self.traderOld);
     self._initTraderEvents();
     self._transitionState('virgin');
   });
@@ -636,9 +642,11 @@ function buildUiCartridges(cartridges, virtualCartridges) {
 }
 
 Brain.prototype._idle = function _idle() {
-  if (!this.pairing.isPaired() && !this.trader.isMock) return this._unpaired();
-  this.trader.sessionId = uuid.v4();
-  console.log('New sessionId: %s', this.trader.sessionId);
+  var trader = this.trader();
+  
+  if (!this.pairing.isPaired() && !trader.isMock) return this._unpaired();
+  trader.sessionId = uuid.v4();
+  console.log('New sessionId: %s', trader.sessionId);
   this.getBillValidator().lightOff();
   this.idVerify.reset();
 
@@ -647,14 +655,14 @@ Brain.prototype._idle = function _idle() {
   if (this.networkDown) return this._networkDown();
 
   // We've got our first contact with server
-  if (this.trader.twoWayMode) this._idleTwoWay();
+  if (trader.twoWayMode) this._idleTwoWay();
   else this._idleOneWay();
 };
 
 Brain.prototype._idleTwoWay = function _idleTwoWay() {
   var self = this;
-  var cartridges = this.trader.cartridges;
-  var virtualCartridges = this.trader.virtualCartridges;
+  var cartridges = this.trader().cartridges;
+  var virtualCartridges = this.trader().virtualCartridges;
   var uiCartridges = buildUiCartridges(cartridges, virtualCartridges);
   var localeInfo = this.localeInfo;
   this.uiCartridges = uiCartridges;
@@ -669,8 +677,8 @@ Brain.prototype._idleTwoWay = function _idleTwoWay() {
   if (this.billDispenser.initializing) return;
 
   this.billDispenser.init({
-    cartridges: this.trader.cartridges,
-    currency: this.trader.locale.currency
+    cartridges: this.trader().cartridges,
+    currency: this.trader().locale.currency
   }, function() {
     self._transitionState(State.DUAL_IDLE,
       {localeInfo: localeInfo, cartridges: uiCartridges});
@@ -699,7 +707,7 @@ Brain.prototype._balanceLow = function _balanceLow() {
 Brain.prototype._start = function _start() {
   if (this.startDisabled) return;
 
-  var fiatBalance = this.trader.balance;
+  var fiatBalance = this.trader().balance;
   var highestBill = this.getBillValidator().highestBill(fiatBalance);
 
   if (!highestBill) return this._balanceLow();
@@ -709,7 +717,7 @@ Brain.prototype._start = function _start() {
 Brain.prototype._startIdScan = function _startIdScan() {
   var self = this;
   this._transitionState('scanId', {beep: true});
-  var sessionId = this.trader.sessionId;
+  var sessionId = this.trader().sessionId;
   this.idVerify.reset();
   this.getBillValidator().lightOn();
   this.scanner.scanPDF417(function (err, result) {
@@ -719,7 +727,7 @@ Brain.prototype._startIdScan = function _startIdScan() {
 
     if (err) throw err;
     var startState = _.contains(['scanId', 'fakeIdle', 'fakeDualIdle'], self.state);
-    var freshState = self.trader.sessionId === sessionId && startState;
+    var freshState = self.trader().sessionId === sessionId && startState;
     if (!freshState) return;
     if (!result) return self._idle();
     self.idVerify.addLicense(result);
@@ -783,7 +791,7 @@ Brain.prototype._stopAlternatingLight = function _stopAlternatingLight() {
 Brain.prototype._startAddressScan = function _startAddressScan() {
   this._transitionState('scanAddress');
   var self = this;
-  var sessionId = this.trader.sessionId;
+  var sessionId = this.trader().sessionId;
 
   this._startAlternatingLight();
   this.scanner.camOn();
@@ -799,7 +807,7 @@ Brain.prototype._startAddressScan = function _startAddressScan() {
     if (err) self.emit('error', err);
     var startState = _.contains(['scanAddress', 'fakeIdle', 'fakeDualIdle'],
       self.state);
-    var freshState = self.trader.sessionId === sessionId && startState;
+    var freshState = self.trader().sessionId === sessionId && startState;
 
     if (!freshState) return;
     if (!address) return self._idle();
@@ -841,7 +849,7 @@ Brain.prototype._idCode = function _idCode(code) {
 };
 
 Brain.prototype._fakeIdle = function _fakeIdle() {
-  var idleState = this.trader.twoWayMode ? 'fakeDualIdle' : 'fakeIdle';
+  var idleState = this.trader().twoWayMode ? 'fakeDualIdle' : 'fakeIdle';
   this._transitionState(idleState);
 };
 
@@ -866,13 +874,13 @@ Brain.prototype._exchangeRateRec = function _exchangeRateRec(rate) {
 };
 
 Brain.prototype._pollUpdate = function _pollUpdate() {
-  var locale = this.trader.locale;
+  var locale = this.trader().locale;
   this.currency = locale.currency;
   this.localeInfo = locale.localeInfo;
   var rec = {
     currency: this.currency,
-    exchangeRate: this._exchangeRateRec(this.trader.exchangeRate),
-    fiatExchangeRate: this.trader.fiatExchangeRate
+    exchangeRate: this._exchangeRateRec(this.trader().exchangeRate),
+    fiatExchangeRate: this.trader().fiatExchangeRate
   };
   if (_.contains(STATIC_STATES, this.state)) {
     rec.localeInfo = this.localeInfo;
@@ -946,7 +954,7 @@ Brain.prototype._assertState = function _assertState(expected) {
 Brain.prototype._handleScan = function _handleScan(address) {
   var self = this;
   this.bitcoinAddress = address;
-  var checkId = this.trader.idVerificationEnabled;
+  var checkId = this.trader().idVerificationEnabled;
   if (checkId) return this._startIdScan();
   this.scanner.camOff(function() { self.startDisabled = false; });
   this._firstBill();
@@ -958,7 +966,7 @@ Brain.prototype._firstBill = function _firstBill() {
   this._setState('acceptingFirstBill');
   this.getBillValidator().enable();
   this._screenTimeout(this._restart.bind(this), this.config.billTimeout);
-  this._logTx({sessionId: this.trader.sessionId, bitcoinAddress: address},
+  this._logTx({sessionId: this.trader().sessionId, bitcoinAddress: address},
       'scanAddress');
 };
 
@@ -972,6 +980,7 @@ Brain.prototype._billInserted = function _billInserted() {
 Brain.prototype._billRead = function _billRead(data) {
   this._createPendingTransaction(data.denomination);
 
+  var trader = this.trader();
   var billValidator = this.getBillValidator();
   var highestBill = null;
   var totalFiat = this.credit.fiat + this.pending.fiat;
@@ -979,9 +988,9 @@ Brain.prototype._billRead = function _billRead(data) {
 
   // Trader balance is balance as of start of user session.
   // Reduce it by fiat we owe user.
-  var fiatBalance = this.trader.balance - totalFiat;
+  var fiatBalance = trader.balance - totalFiat;
 
-  var txLimit = this.trader.txLimit;
+  var txLimit = trader.txLimit;
   if (txLimit && totalFiat > txLimit) {
 	billValidator.reject();
     this.pending = null;
@@ -1020,7 +1029,7 @@ Brain.prototype._billRead = function _billRead(data) {
     returnState = this.credit.fiat === 0 ?
         'acceptingFirstBill' : 'acceptingBills';
     this._setState(returnState, 'billInserted');
-    var newFiatBalance = this.trader.balance - this.credit.fiat;
+    var newFiatBalance = trader.balance - this.credit.fiat;
     var newHighestBill = billValidator.highestBill(newFiatBalance);
 
     if (newHighestBill)
@@ -1060,14 +1069,15 @@ Brain.prototype._billValid = function _billValid() {
   tradeRec.toAddress = this.bitcoinAddress;
   tradeRec.partialTx = _.clone(this.credit);
 
-  this.trader.trade(tradeRec, function(err) {
+  var trader = this.trader();
+  trader.trade(tradeRec, function(err) {
     if (!err) {
       self.creditConfirmed.fiat += pending.fiat;
       self.creditConfirmed.satoshis += pending.satoshis;
     }
   });
 
-  var txLimit = this.trader.txLimit;
+  var txLimit = trader.txLimit;
   var billValidator = this.getBillValidator();
   if (txLimit !== null &&
       this.credit.fiat + billValidator.lowestBill() > txLimit) {
@@ -1169,7 +1179,7 @@ function satoshisToBitcoins(satoshis) {
 Brain.prototype._createPendingTransaction =
     function _createPendingTransaction(bill) {
   console.assert(this.pending === null, 'pending is null, can\'t start tx');
-  var exchangeRate = this.trader.exchangeRate;
+  var exchangeRate = this.trader().exchangeRate;
   console.assert(exchangeRate, 'Exchange rate not set');
   var satoshiRate = SATOSHI_FACTOR / exchangeRate;
   var satoshis = truncateSatoshis(bill * satoshiRate);
@@ -1221,7 +1231,7 @@ Brain.prototype._doSendBitcoins = function _doSendBitcoins() {
     currencyCode: this.currency,
     fiat: this.credit.fiat
   };
-  this.trader.sendBitcoins(tx, function(err, transactionId) {
+  this.trader().sendBitcoins(tx, function(err, transactionId) {
     var unconfirmedFiat = self.credit.fiat - self.creditConfirmed.fiat;
     if (err && unconfirmedFiat > 0) self._sendBitcoinsError(err);
     else self._cashInComplete(transactionId);
@@ -1238,7 +1248,7 @@ Brain.prototype._sendBitcoinsError = function _sendBitcoinsError(err) {
 
   var withdrawFailureRec = {
     credit: this._uiCredit(),
-    sessionId: this.trader.sessionId
+    sessionId: this.trader().sessionId
   };
 
   // Giving up
@@ -1279,7 +1289,7 @@ Brain.prototype._cashInComplete =
 
   this.browser().send({
     action: 'bitcoinTransferComplete',
-    sessionId: this.trader.sessionId
+    sessionId: this.trader().sessionId
   });
 
   var rec = {
@@ -1333,7 +1343,7 @@ Brain.prototype._completed = function _completed() {
 
   this._transitionState('goodbye');
 
-  this.trader.sessionId = null;
+  this.trader().sessionId = null;
 
   var elapsed = Date.now() - this.bootTime;
   if (elapsed > this.config.exitTime) {
@@ -1438,7 +1448,7 @@ Brain.prototype._unpair = function _unpair() {
   var self = this;
 
   console.log('Unpairing');
-  self.trader.stop();
+  self.trader().stop();
   self.pairing.unpair(function () {
     console.log('Unpaired');
     self._setState('unpaired');
@@ -1463,9 +1473,11 @@ Brain.prototype._billValidatorErr = function _billValidatorErr(err) {
 
 Brain.prototype._getFiatButtonResponse = function _getFiatButtonResponse() {
   var tx = this.fiatTx;
-  var cartridges = this.trader.cartridges;
-  var virtualCartridges = this.trader.virtualCartridges;
-  var txLimit = this.trader.fiatTxLimit;
+  var trader = this.trader();
+  
+  var cartridges = trader.cartridges;
+  var virtualCartridges = trader.virtualCartridges;
+  var txLimit = trader.fiatTxLimit;
   var activeDenominations =
     this.billDispenser.activeDenominations(txLimit, tx.fiat, cartridges,
     virtualCartridges);
@@ -1479,7 +1491,7 @@ Brain.prototype._getFiatButtonResponse = function _getFiatButtonResponse() {
 };
 
 Brain.prototype._hasCash = function _hasCash() {
-  return _.max(_.pluck(this.trader.cartridges, 'count')) > 0;
+  return _.max(_.pluck(this.trader().cartridges, 'count')) > 0;
 };
 
 Brain.prototype._outOfCash = function _outOfCash() {
@@ -1499,7 +1511,7 @@ Brain.prototype._outOfCash = function _outOfCash() {
 
 Brain.prototype._chooseFiat = function _chooseFiat() {
   if (!this._hasCash()) return this._outOfCash();
-  var sessionId = this.trader.sessionId;
+  var sessionId = this.trader().sessionId;
   this.fiatTx = {
     fiat: 0,
     satoshis: 0,
@@ -1512,7 +1524,7 @@ Brain.prototype._chooseFiat = function _chooseFiat() {
   this.dirtyScreen = false;
   var interval = setInterval(function () {
     var doClear = self.state !== 'chooseFiat' ||
-      self.trader.sessionId !== sessionId;
+    self.trader().sessionId !== sessionId;
     if (doClear) return clearInterval(interval);
 
     var isDirty = self.dirtyScreen;
@@ -1535,7 +1547,7 @@ Brain.prototype._fiatButtonResponse = function _fiatButtonResponse() {
 
 Brain.prototype._fiatButton = function _fiatButton(data) {
   var denomination = parseInt(data.denomination);
-  var rate = this.trader.fiatExchangeRate;
+  var rate = this.trader().fiatExchangeRate;
   var tx = this.fiatTx;
 
   tx.fiat += denomination;
@@ -1568,7 +1580,7 @@ Brain.prototype._cashOut = function _cashOut() {
   this._transitionState('deposit', {tx: tx});
   timeout();
 
-  this.trader.cashOut(tx, function (err, bitcoinAddress) {
+  this.trader().cashOut(tx, function (err, bitcoinAddress) {
     if (err) self._idle();
     tx.toAddress = bitcoinAddress;
     self.browser().send({depositInfo: tx});
@@ -1624,24 +1636,25 @@ Brain.prototype._dispenseUpdate = function _dispenseUpdate(dispenseStatus) {
     case 'authorized':
     case 'confirmed':
       var fiat = dispenseStatus.fiat;
-      var cartridges = this.trader.cartridges;
+      var trader = self.trader();
+      var cartridges = trader.cartridges;
       this.billDispenser.dispense(fiat, cartridges, function (err, result) {
         if (err) throw new Error(err);    // TODO special error screen
 
         var bills = result.bills;
         var tx = self.fiatTx;
-        var cartridges = self.trader.cartridges;
+        var cartridges = trader.cartridges;
         var wasFullDispense = fullDispense(bills, tx.fiat, cartridges);
         fillInBills(tx, bills);
         tx.error = result.err;
-        self.trader.dispenseAck(tx);
+        trader.dispenseAck(tx);
         if (!wasFullDispense)
           return self._transitionState('outOfCash');
 
-        var sessionId = self.trader.sessionId;
+        var sessionId = trader.sessionId;
         setTimeout(function () {
           var doComplete = self.state === 'fiatComplete' &&
-            self.trader.sessionId === sessionId;
+          trader.sessionId === sessionId;
           if (doComplete)
             self._completed();
         }, 60000);
@@ -1666,6 +1679,14 @@ Brain.prototype.browser = function browser() {
 
 Brain.prototype.setBrowser = function setBrowser(obj) {
 	this.browserObj = obj;
+};
+
+Brain.prototype.trader = function trader() {
+	return this.traderObj;
+};
+
+Brain.prototype.setTrader = function setTrader(obj) {
+	this.traderObj = obj;
 };
 
 function startsWithUSB(file) {

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -62,7 +62,7 @@ var Brain = function(config) {
     certs: certs,
     connectionInfoPath: connectionInfoPath
   };
-  this.pairing = require('./pairing')(pairingConfig);
+  this.setPairing(require('./pairing')(pairingConfig));
 
   config.id003.currency = this.currency;
   this.setBillValidator(require('./id003/id003').factory(config.id003));
@@ -201,8 +201,8 @@ Brain.prototype._periodicLog = function _periodicLog() {
 
 Brain.prototype._connect = function _connect() {
   var self = this;
-  if (!this.pairing.hasCert()) this._transitionState('initializing');
-  this.pairing.init(function (err) {
+  if (!this.pairing().hasCert()) this._transitionState('initializing');
+  this.pairing().init(function (err) {
     if (err) self.emit('error', err);
     self._startTrading();
   });
@@ -214,7 +214,7 @@ Brain.prototype._startTrading = function _startTrading() {
     if (err) return self._billValidatorErr(err);
 
     console.log('Bill validator connected.');
-    self.trader().init(self.pairing.connectionInfo());
+    self.trader().init(self.pairing().connectionInfo());
 
     // We want to wait until heavy CPU heavy certification generation is done
     self.getBillValidator().monitorHeartbeat();
@@ -564,7 +564,7 @@ Brain.prototype._wifiConnected = function _wifiConnected() {
   if (this.state === 'maintenance') return;
   this._setState('wifiConnected');
 
-  if (!this.pairing.hasCert()) return this._transitionState('virgin');
+  if (!this.pairing().hasCert()) return this._transitionState('virgin');
   this._connect();
 };
 
@@ -590,7 +590,7 @@ Brain.prototype._pairingScan = function _pairingScan() {
 Brain.prototype._pair = function _pair(json) {
   var self = this;
   this._transitionState('pairing');
-  this.pairing.pair(json, function (err, connectionInfo) {
+  this.pairing().pair(json, function (err, connectionInfo) {
     if (err) return self._pairingError(err);
     self.trader().pair(connectionInfo);
     self._idle();
@@ -613,7 +613,7 @@ Brain.prototype._testMode = function _testMode() {
   this.trader().removeAllListeners();
   this.setTrader(require('./mocks/trader')());
   this._initTraderEvents();
-  this.pairing._connectionInfo = {};
+  this.pairing()._connectionInfo = {};
   this.networkDown = false;
   this.getBillValidator().run(function () {
 	  self.trader().run();
@@ -625,7 +625,7 @@ Brain.prototype._testModeOff = function _testModeOff() {
   var self = this;
   this.getBillValidator().close(function() {
     self.testModeOn = false;
-    self.pairing._connectionInfo = null;
+    self.pairing()._connectionInfo = null;
     self.trader().removeAllListeners();
     self.setTrader(self.traderOld);
     self._initTraderEvents();
@@ -643,8 +643,9 @@ function buildUiCartridges(cartridges, virtualCartridges) {
 
 Brain.prototype._idle = function _idle() {
   var trader = this.trader();
+  var pairing = this.pairing();
   
-  if (!this.pairing.isPaired() && !trader.isMock) return this._unpaired();
+  if (!pairing.isPaired() && !trader.isMock) return this._unpaired();
   trader.sessionId = uuid.v4();
   console.log('New sessionId: %s', trader.sessionId);
   this.getBillValidator().lightOff();
@@ -1449,7 +1450,7 @@ Brain.prototype._unpair = function _unpair() {
 
   console.log('Unpairing');
   self.trader().stop();
-  self.pairing.unpair(function () {
+  self.pairing().unpair(function () {
     console.log('Unpaired');
     self._setState('unpaired');
     self.browser().send({action: 'unpaired'});
@@ -1687,6 +1688,14 @@ Brain.prototype.trader = function trader() {
 
 Brain.prototype.setTrader = function setTrader(obj) {
 	this.traderObj = obj;
+};
+
+Brain.prototype.pairing = function pairing() {
+	return this.pairingObj;
+};
+
+Brain.prototype.setPairing = function setPairing(obj) {
+	this.pairingObj = obj;
 };
 
 function startsWithUSB(file) {

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -217,7 +217,7 @@ Brain.prototype._startTrading = function _startTrading() {
     self.trader().init(self.pairing.connectionInfo());
 
     // We want to wait until heavy CPU heavy certification generation is done
-    self.billValidator.monitorHeartbeat();
+    self.getBillValidator().monitorHeartbeat();
 
     self.trader().run();
     self._idle();
@@ -721,7 +721,7 @@ Brain.prototype._startIdScan = function _startIdScan() {
   this.idVerify.reset();
   this.getBillValidator().lightOn();
   this.scanner.scanPDF417(function (err, result) {
-    self.billValidator.lightOff();
+    self.getBillValidator().lightOff();
     clearTimeout(self.screenTimeout);
     self.scanner.camOff(function() { self.startDisabled = false; });
 
@@ -772,11 +772,11 @@ Brain.prototype._startAlternatingLight = function _startAlternatingLight() {
     count++;
     if (lastState === 'off') {
       if (count < offSkip) return;
-      self.billValidator.lightOn();
+      self.getBillValidator().lightOn();
       lastState = 'on';
     } else {
       if (count < onSkip) return;
-      self.billValidator.lightOff();
+      self.getBillValidator().lightOff();
       lastState = 'off';
     }
     count = 0;

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -69,7 +69,7 @@ var Brain = function(config) {
 
   var traderConfig = config.trader;
   traderConfig.currency = this.currency;
-  traderConfig.lowestBill = this.getBillValidator().lowestBill();
+  traderConfig.lowestBill = this.billValidator().lowestBill();
   traderConfig.certs = certs;
   if (config.http) traderConfig.protocol = 'http';
 
@@ -210,7 +210,7 @@ Brain.prototype._connect = function _connect() {
 
 Brain.prototype._startTrading = function _startTrading() {
   var self = this;
-  this.getBillValidator().run(function (err) {
+  this.billValidator().run(function (err) {
     if (err) return self._billValidatorErr(err);
 
     console.log('Bill validator connected.');
@@ -304,7 +304,7 @@ Brain.prototype._initBrowserEvents = function _initBrowserEvents() {
 
 Brain.prototype._initBillValidatorEvents = function _initBillValidatorEvents() {
   var self = this;
-  var billValidator = this.getBillValidator();
+  var billValidator = this.billValidator();
   
   billValidator.on('error', function(err) { self._billValidatorErr(err); });
   billValidator.on('disconnected', function() { self._billValidatorErr(); });
@@ -627,7 +627,7 @@ Brain.prototype._testMode = function _testMode() {
   this._initTraderEvents();
   this.pairing()._connectionInfo = {};
   this.networkDown = false;
-  this.getBillValidator().run(function () {
+  this.billValidator().run(function () {
 	  self.trader().run();
     self._idle();
   });
@@ -635,7 +635,7 @@ Brain.prototype._testMode = function _testMode() {
 
 Brain.prototype._testModeOff = function _testModeOff() {
   var self = this;
-  this.getBillValidator().close(function() {
+  this.billValidator().close(function() {
     self.testModeOn = false;
     self.pairing()._connectionInfo = null;
     self.trader().removeAllListeners();
@@ -660,7 +660,7 @@ Brain.prototype._idle = function _idle() {
   if (!pairing.isPaired() && !trader.isMock) return this._unpaired();
   trader.sessionId = uuid.v4();
   console.log('New sessionId: %s', trader.sessionId);
-  this.getBillValidator().lightOff();
+  this.billValidator().lightOff();
   this.idVerify.reset();
 
   this._setState(State.PENDING_IDLE);
@@ -721,7 +721,7 @@ Brain.prototype._start = function _start() {
   if (this.startDisabled) return;
 
   var fiatBalance = this.trader().balance;
-  var highestBill = this.getBillValidator().highestBill(fiatBalance);
+  var highestBill = this.billValidator().highestBill(fiatBalance);
 
   if (!highestBill) return this._balanceLow();
   this._startAddressScan();
@@ -732,7 +732,7 @@ Brain.prototype._startIdScan = function _startIdScan() {
   this._transitionState('scanId', {beep: true});
   var sessionId = this.trader().sessionId;
   this.idVerify.reset();
-  this.getBillValidator().lightOn();
+  this.billValidator().lightOn();
   this.scanner.scanPDF417(function (err, result) {
     self.getBillValidator().lightOff();
     clearTimeout(self.screenTimeout);
@@ -778,9 +778,9 @@ Brain.prototype._startAlternatingLight = function _startAlternatingLight() {
   var count = 0;
 
   if (!onInterval) return;
-  if (!offInterval) return this.getBillValidator().lightOn();
+  if (!offInterval) return this.billValidator().lightOn();
 
-  this.getBillValidator().lightOn();
+  this.billValidator().lightOn();
   this.alternatingLightTimer = setInterval(function() {
     count++;
     if (lastState === 'off') {
@@ -798,7 +798,7 @@ Brain.prototype._startAlternatingLight = function _startAlternatingLight() {
 
 Brain.prototype._stopAlternatingLight = function _stopAlternatingLight() {
   clearInterval(this.alternatingLightTimer);
-  this.getBillValidator().lightOff();
+  this.billValidator().lightOff();
 };
 
 Brain.prototype._startAddressScan = function _startAddressScan() {
@@ -874,7 +874,7 @@ Brain.prototype._cancelScan = function _cancelScan() {
 
 Brain.prototype._cancelInsertBill = function _cancelInsertBill() {
   this._idle();
-  this.getBillValidator().disable();
+  this.billValidator().disable();
 };
 
 Brain.prototype._exchangeRateRec = function _exchangeRateRec(rate) {
@@ -904,7 +904,7 @@ Brain.prototype._pollUpdate = function _pollUpdate() {
 Brain.prototype._networkDown = function _networkDown() {
   this.networkDown = true;
   if (_.contains(BILL_ACCEPTING_STATES, this.state)) {
-	this.getBillValidator().disable();
+	this.billValidator().disable();
 	this.browser().send({sendOnly: true});
     return;
   }
@@ -928,7 +928,7 @@ Brain.prototype._forceNetworkDown = function _forceNetworkDown() {
 
 Brain.prototype._networkUp = function _networkUp() {
   // Don't go to start screen yet
-  if (!this.getBillValidator().hasDenominations()) return;
+  if (!this.billValidator().hasDenominations()) return;
 
   this.networkDown = false;
   if (_.contains([State.NETWORK_DOWN, 'connecting', 'wifiConnected'], this.state))
@@ -954,7 +954,7 @@ Brain.prototype._bitcoinFractionalDigits =
 Brain.prototype._restart = function _restart() {
   console.assert(!this.billsPending, 'Shouldn\'t restart, bills are pending!');
   this._resetState();
-  this.getBillValidator().disable();
+  this.billValidator().disable();
   this._idle();
 };
 
@@ -977,7 +977,7 @@ Brain.prototype._firstBill = function _firstBill() {
   var address = this.bitcoinAddress;
   this.browser().send({action: 'scanned', buyerAddress: address});
   this._setState('acceptingFirstBill');
-  this.getBillValidator().enable();
+  this.billValidator().enable();
   this._screenTimeout(this._restart.bind(this), this.config.billTimeout);
   this._logTx({sessionId: this.trader().sessionId, bitcoinAddress: address},
       'scanAddress');
@@ -994,7 +994,7 @@ Brain.prototype._billRead = function _billRead(data) {
   this._createPendingTransaction(data.denomination);
 
   var trader = this.trader();
-  var billValidator = this.getBillValidator();
+  var billValidator = this.billValidator();
   var highestBill = null;
   var totalFiat = this.credit.fiat + this.pending.fiat;
   var returnState;
@@ -1091,7 +1091,7 @@ Brain.prototype._billValid = function _billValid() {
   });
 
   var txLimit = trader.txLimit;
-  var billValidator = this.getBillValidator();
+  var billValidator = this.billValidator();
   if (txLimit !== null &&
       this.credit.fiat + billValidator.lowestBill() > txLimit) {
     billValidator.disable();
@@ -1145,7 +1145,7 @@ Brain.prototype._billRejected = function _billRejected() {
 
 Brain.prototype._billStandby = function _billStandby() {
   if (this.state === 'acceptingBills' || this.state === 'acceptingFirstBill')
-    this.getBillValidator().enable();
+    this.billValidator().enable();
 };
 
 Brain.prototype._billJam = function _billJam() {
@@ -1216,7 +1216,7 @@ Brain.prototype._sendBitcoins = function _sendBitcoins() {
 
 Brain.prototype._doSendBitcoins = function _doSendBitcoins() {
   this._setState('bitcoinsSent', 'acceptingBills');
-  this.getBillValidator().disable();
+  this.billValidator().disable();
 
   this.pending = null;
 
@@ -1464,7 +1464,7 @@ Brain.prototype._billValidatorErr = function _billValidatorErr(err) {
 
   if (this.billsPending) {
     this.billValidatorErrorFlag = true;
-    this.getBillValidator().disable(); // Just in case. If error, will get throttled.
+    this.billValidator().disable(); // Just in case. If error, will get throttled.
     this.browser().send({credit: this._uiCredit(), sendOnly: true});
     return;
   }
@@ -1666,12 +1666,12 @@ Brain.prototype._dispenseUpdate = function _dispenseUpdate(dispenseStatus) {
   }
 };
 
-Brain.prototype.getBillValidator = function getBillValidator() {
-	return this.billValidator;
+Brain.prototype.billValidator = function billValidator() {
+	return this.billValidatorObj;
 };
 
 Brain.prototype.setBillValidator = function setBillValidator(obj) {
-	this.billValidator = obj;
+	this.billValidatorObj = obj;
 };
 
 Brain.prototype.browser = function browser() {

--- a/lib/constants/state.js
+++ b/lib/constants/state.js
@@ -1,6 +1,8 @@
 'use strict';
 
+exports.ACCEPTING_BILL = 'acceptingBill';
 exports.BALANCE_LOW = 'balanceLow';
+exports.BILL_INSERTED = 'billInserted';
 exports.DUAL_IDLE = 'dualIdle';
 exports.IDLE = 'idle';
 exports.NETWORK_DOWN = 'networkDown';

--- a/lib/constants/state.js
+++ b/lib/constants/state.js
@@ -1,6 +1,7 @@
 'use strict';
 
 exports.BALANCE_LOW = 'balanceLow';
+exports.DUAL_IDLE = 'dualIdle';
 exports.IDLE = 'idle';
 exports.NETWORK_DOWN = 'networkDown';
 exports.PENDING_IDLE = 'pendingIdle';

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -43,6 +43,39 @@ describe('Brain', function() {
 	  });
   });
   
+  describe('when _unpair is called', function() {
+	  it('then trader is stopped', function() {
+		  var callback = jasmine.createSpyObj('callback', ['stop']);
+		  
+		  spyOn(brain, 'trader').and.returnValue(callback);
+		  
+		  brain._unpair();
+		  
+		  expect(callback.stop).toHaveBeenCalled();
+	  });
+	  
+	  describe('then on the pairing object', function() {
+		  it('.unpair is called', function() {
+			  var traderCallback = jasmine.createSpyObj('traderCallback', ['stop']);
+			  var pairingCallback = jasmine.createSpyObj('pairingCallback', ['unpair']);
+			  
+			  spyOn(brain, 'trader').and.returnValue(traderCallback);
+			  spyOn(brain, 'pairing').and.returnValue(pairingCallback);
+			  
+			  brain._unpair();
+			  
+			  expect(traderCallback.stop).toHaveBeenCalled();
+			  expect(pairingCallback.unpair).toHaveBeenCalled();
+		  });
+		  
+		  it('.unpair calls the callback', function() {
+			  // TODO: verify that the callback is called, and that it 
+			  //	1 sets the brain state to UNPAIRED
+			  //	2 sends a msg to the browser saying 'UNPAIRED'
+		  });
+	  });
+  });
+  
   describe('when _billJam is called', function () {
 	 it('then a State.NETWORK_DOWN msg is sent to the browser', function() {
 		 var callback = jasmine.createSpyObj('callback', ['send']);

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -26,6 +26,23 @@ describe('Brain', function() {
     expect(brain.state).toBe(State.START);
   });
   
+  describe(', when _unpaired is called', function() {
+	  it(', then a State.UNPAIRED msg is sent to the browser', function() {
+		 var callback = jasmine.createSpyObj('callback', ['send']);
+		 
+		 spyOn(brain, 'browser').and.returnValue(callback);
+		 
+		 brain._unpaired();
+		 
+		 expect(callback.send).toHaveBeenCalledWith({action: State.UNPAIRED});
+	  });
+	  
+	  it(', then the state is set to State.UNPAIRED', function() {
+		 brain._unpaired();
+		 expect(brain.state).toBe(State.UNPAIRED);
+	  });
+  });
+  
   describe(', when _billJam is called', function () {
 	 it(', then a State.NETWORK_DOWN msg is sent to the browser', function() {
 		 var callback = jasmine.createSpyObj('callback', ['send']);
@@ -35,6 +52,14 @@ describe('Brain', function() {
 		 brain._billJam();
 		 
 		 expect(callback.send).toHaveBeenCalledWith({action: State.NETWORK_DOWN});
+	 });
+	 
+	 it(', the Brain state is not changed', function () {
+		 var state = brain.state;
+		 
+		 brain._billJam();
+		 
+		 expect(brain.state).toBe(state);
 	 });
   });
   

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -26,8 +26,8 @@ describe('Brain', function() {
     expect(brain.state).toBe(State.START);
   });
   
-  describe(', when _unpaired is called', function() {
-	  it(', then a State.UNPAIRED msg is sent to the browser', function() {
+  describe('when _unpaired is called', function() {
+	  it('then a State.UNPAIRED msg is sent to the browser', function() {
 		 var callback = jasmine.createSpyObj('callback', ['send']);
 		 
 		 spyOn(brain, 'browser').and.returnValue(callback);
@@ -43,8 +43,8 @@ describe('Brain', function() {
 	  });
   });
   
-  describe(', when _billJam is called', function () {
-	 it(', then a State.NETWORK_DOWN msg is sent to the browser', function() {
+  describe('when _billJam is called', function () {
+	 it('then a State.NETWORK_DOWN msg is sent to the browser', function() {
 		 var callback = jasmine.createSpyObj('callback', ['send']);
 		 
 		 spyOn(brain, 'browser').and.returnValue(callback);
@@ -54,7 +54,7 @@ describe('Brain', function() {
 		 expect(callback.send).toHaveBeenCalledWith({action: State.NETWORK_DOWN});
 	 });
 	 
-	 it(', the Brain state is not changed', function () {
+	 it('the Brain state is not changed', function () {
 		 var state = brain.state;
 		 
 		 brain._billJam();
@@ -63,8 +63,8 @@ describe('Brain', function() {
 	 });
   });
   
-  describe(', when _forceNetworkDown is called', function() {
-	  it(', and brain.hasConnected is true, state becomes State.NETWORK_DOWN', function() {
+  describe('when _forceNetworkDown is called', function() {
+	  it('and brain.hasConnected is true, state becomes State.NETWORK_DOWN', function() {
 		  brain.hasConnected = true;
 		  
 		  brain._forceNetworkDown();
@@ -73,9 +73,9 @@ describe('Brain', function() {
 	  });
   });
   
-  describe(', when _networkUp is called', function () {
-	  describe(', and state is State.NETWORK_DOWN', function() {
-		  it(', then _restart() is called', function() {
+  describe('when _networkUp is called', function () {
+	  describe('and state is State.NETWORK_DOWN', function() {
+		  it('then _restart() is called', function() {
 			  spyOn(brain, '_restart');
 			  spyOn(brain, 'getBillValidator').and.callFake(function() {
 				  var rtn = {};
@@ -96,8 +96,8 @@ describe('Brain', function() {
 	  });
   });
   
-  describe(', when _idle() is called', function() {
-	  it(', state becomes State.PENDING_IDLE', function () {
+  describe('when _idle() is called', function() {
+	  it('state becomes State.PENDING_IDLE', function () {
 		  spyOn(brain, '_setState');
 		  
 		  brain._idle();
@@ -105,7 +105,7 @@ describe('Brain', function() {
 		  expect(brain._setState).toHaveBeenCalledWith(State.PENDING_IDLE);
 	  });
 	  
-	  it(', and trader.twoWayMode is true, don\'t expect state to become State.IDLE', function() {
+	  it('and trader.twoWayMode is true, don\'t expect state to become State.IDLE', function() {
 		  brain.networkDown = false;
 		  brain.trader().twoWayMode = true;
 		  
@@ -116,7 +116,7 @@ describe('Brain', function() {
 		  expect(brain._setState).not.toHaveBeenCalledWith(State.IDLE);
 	  });
 
-	  it(', and trader.twoWayMode is false, expect state to become State.IDLE', function() {
+	  it('and trader.twoWayMode is false, expect state to become State.IDLE', function() {
 		  brain.networkDown = false;
 		  brain.trader().twoWayMode = false;
 		  
@@ -130,8 +130,8 @@ describe('Brain', function() {
 	  });
   });
   
-  describe(', when _idleOneWay is called', function() {
-	  it(', state becomes State.IDLE', function() {
+  describe('when _idleOneWay is called', function() {
+	  it('state becomes State.IDLE', function() {
 		  spyOn(brain, '_setState');
 		  
 		  brain._idleOneWay();

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -250,6 +250,13 @@ describe('Brain', function() {
 		  brain.setTrader(obj2);
 		  expect(brain.trader()).toBe(obj2);
 	  }); 
+
+	  it('Pairing', function() {
+		  brain.setPairing(obj);
+		  expect(brain.pairing()).toBe(obj);
+		  brain.setPairing(obj2);
+		  expect(brain.pairing()).toBe(obj2);
+	  }); 
   }); /* getters and setters */
 
 }); /* Brain */

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -76,6 +76,23 @@ describe('Brain', function() {
 	  });
   });
   
+  describe('when _billInserted is called', function() {
+	  it('then a State.ACCEPTING_BILL msg is sent to the browser', function() {
+		 var callback = jasmine.createSpyObj('callback', ['send']);
+		 
+		 spyOn(brain, 'browser').and.returnValue(callback);
+		 
+		 brain._billInserted();
+		 
+		 expect(callback.send).toHaveBeenCalledWith({action: State.ACCEPTING_BILL});
+	  });
+	  
+	  it('state becomes State.BILL_INSERTED', function() {
+		  brain._billInserted();
+		  expect(brain.state).toBe(State.BILL_INSERTED);
+	  });
+  });
+  
   describe('when _billJam is called', function () {
 	 it('then a State.NETWORK_DOWN msg is sent to the browser', function() {
 		 var callback = jasmine.createSpyObj('callback', ['send']);

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -177,10 +177,21 @@ describe('Brain', function() {
 		    theTest(State.PENDING_IDLE);
 	  });
 
+	  it('when state is State.DUAL_IDLE', function() {
+		    theTest(State.DUAL_IDLE);
+	  });
+
 	  it('when state is State.NETWORK_DOWN', function() {
 		    theTest(State.NETWORK_DOWN);
 	  });
+	  
+	  it('when state is State.UNPAIRED', function() {
+		    theTest(State.UNPAIRED);
+	  });
 
+	  it('when state is "foo"', function() {
+		    theTest('foo', EXPECT_TO_FAIL);
+	  });
   });
   
   describe('initializes', function() {

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -243,6 +243,13 @@ describe('Brain', function() {
 		  brain.setBrowser(obj2);
 		  expect(brain.browser()).toBe(obj2);
 	  }); 
+
+	  it(' Trader', function() {
+		  brain.setTrader(obj);
+		  expect(brain.trader()).toBe(obj);
+		  brain.setTrader(obj2);
+		  expect(brain.trader()).toBe(obj2);
+	  }); 
   }); /* getters and setters */
 
 }); /* Brain */

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -107,7 +107,7 @@ describe('Brain', function() {
 	  
 	  it(', and trader.twoWayMode is true, don\'t expect state to become State.IDLE', function() {
 		  brain.networkDown = false;
-		  brain.trader.twoWayMode = true;
+		  brain.trader().twoWayMode = true;
 		  
 		  spyOn(brain, '_setState');
 		  
@@ -118,7 +118,7 @@ describe('Brain', function() {
 
 	  it(', and trader.twoWayMode is false, expect state to become State.IDLE', function() {
 		  brain.networkDown = false;
-		  brain.trader.twoWayMode = false;
+		  brain.trader().twoWayMode = false;
 		  
 		  spyOn(brain, '_setState');
 		  spyOn(brain, '_idleOneWay').and.callThrough();
@@ -196,7 +196,7 @@ describe('Brain', function() {
 
     it('its trader correctly', function() {
       var events = [State.POLL_UPDATE, State.NETWORK_DOWN, 'networkUp', 'dispenseUpdate', 'error', 'unpair'];
-      func(events, brain._initTraderEvents, brain.trader);
+      func(events, brain._initTraderEvents, brain.trader());
     });
 
     it('its browser correctly', function() {

--- a/test/brain-test.js
+++ b/test/brain-test.js
@@ -110,7 +110,7 @@ describe('Brain', function() {
 	  describe('and state is State.NETWORK_DOWN', function() {
 		  it('then _restart() is called', function() {
 			  spyOn(brain, '_restart');
-			  spyOn(brain, 'getBillValidator').and.callFake(function() {
+			  spyOn(brain, 'billValidator').and.callFake(function() {
 				  var rtn = {};
 
 				  rtn.hasDenominations = function() {
@@ -255,7 +255,7 @@ describe('Brain', function() {
 
     it('its billValidator correctly', function() {
       var events = ['error', 'disconnected', 'billAccepted', 'billRead', 'billValid', 'billRejected', 'timeout', 'standby', 'jam', 'stackerOpen', 'enabled'];
-      func(events, brain._initBillValidatorEvents, brain.getBillValidator());
+      func(events, brain._initBillValidatorEvents, brain.billValidator());
     });
 
     it('its own event listeners correctly', function() {
@@ -276,9 +276,9 @@ describe('Brain', function() {
 	  
 	  it(' BillValidator', function() {
 		  brain.setBillValidator(obj);
-		  expect(brain.getBillValidator()).toBe(obj);
+		  expect(brain.billValidator()).toBe(obj);
 		  brain.setBillValidator(obj2);
-		  expect(brain.getBillValidator()).toBe(obj2);
+		  expect(brain.billValidator()).toBe(obj2);
 	  }); 
 
 	  it(' Browser', function() {


### PR DESCRIPTION
Worked on .pairing, .trader, .browser and .billValidator, adding getters and setters for each of them. Added unit tests for the getters and setters. Added unit tests for theBrain. _unpair() method and the constant State.UNPAIRED. Added unit test for the _billInserted() method.