### PR TITLE
Error (Yiddish)

### DIFF
--- a/ui/js/vendor/langmap.js
+++ b/ui/js/vendor/langmap.js
@@ -729,7 +729,7 @@
     },
     'zh-TW': {
       nativeName: "中文(台灣)",
-      englishName: "Chinese (Taiwan)"
+      englishName: "Chinese"
     },
     'zu-ZA': {
       nativeName: "isiZulu",

--- a/ui/js/vendor/langmap.js
+++ b/ui/js/vendor/langmap.js
@@ -716,8 +716,8 @@
       englishName: "Yiddish"
     },
     'yi-DE': {
-      nativeName: "ייִדיש (German)",
-      englishName: "Yiddish (German)"
+      nativeName: "ייִדיש (Germany)",
+      englishName: "Yiddish (Germany)"
     },
     'zh-CN': {
       nativeName: "中文(简体)",
@@ -729,7 +729,7 @@
     },
     'zh-TW': {
       nativeName: "中文(台灣)",
-      englishName: "Chinese"
+      englishName: "Chinese (Taiwan)"
     },
     'zu-ZA': {
       nativeName: "isiZulu",


### PR DESCRIPTION
I very much assume "Yiddish (German)" is supposed to mean "Yiddish (Germany)", as Yiddish and German are two separate languages and given the DE country code in yi-DE .