### PR TITLE
Accept either bitcoin: or Bitcoin: URIs

### DIFF
--- a/lib/coins/btc.js
+++ b/lib/coins/btc.js
@@ -4,7 +4,7 @@ const _ = require('lodash/fp')
 module.exports = {depositUrl, parseUrl}
 
 function parseUrl (network, url) {
-  const res = /^(bitcoin:\/{0,2})?(\w+)/.exec(url)
+  const res = /^([bB]itcoin:\/{0,2})?(\w+)/.exec(url)
   const address = res && res[2]
 
   console.log('DEBUG16: [%s] *%s*', network, address)


### PR DESCRIPTION
Operator reports that some wallets use QR codes with `Bitcoin:` as the URI, resulting in:

```
2018-01-31T02:08:09.842Z LOG new brain state: scanAddress
2018-01-31T02:08:18.943Z LOG DEBUG55: Bitcoin:1[redacted]
2018-01-31T02:08:18.945Z LOG DEBUG16: [main] Bitcoin
2018-01-31T02:08:18.967Z LOG Error: Invalid checksum
   at Object.decode (/opt/apps/machine/lamassu-machine/node_modules/bs58check/index.js:46:23)
   at validate (/opt/apps/machine/lamassu-machine/lib/coins/btc.js:26:27)
   at Object.parseUrl (/opt/apps/machine/lamassu-machine/lib/coins/btc.js:12:8)
   at Object.parseUrl (/opt/apps/machine/lamassu-machine/lib/coins/utils.js:53:17)
   at /opt/apps/machine/lamassu-machine/lib/scanner.js:138:37
   at Camera.cam.stop (/opt/apps/machine/lamassu-machine/lib/scanner.js:96:18)
```
Best to accept either case.