### PR TITLE
Resync machine time to prevent clock skew error

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -415,6 +415,7 @@ Brain.prototype._setUpN7 = function _setUpN7 () {
 Brain.prototype._connectedBrowser = function _connectedBrowser () {
   //  TODO: have to work on this: console.assert(this.state === State.IDLE)
   console.log('connected to browser')
+  var timeResync = cp.exec('bash /opt/apps/machine/lamassu-machine/lib/timeResync.sh')
 
   const wifiList = this.state === 'wifiList' && this.wifis
   ? this.wifis

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -415,8 +415,10 @@ Brain.prototype._setUpN7 = function _setUpN7 () {
 Brain.prototype._connectedBrowser = function _connectedBrowser () {
   //  TODO: have to work on this: console.assert(this.state === State.IDLE)
   console.log('connected to browser')
-  var timeResync = cp.exec('bash /opt/apps/machine/lamassu-machine/lib/timeResync.sh')
-  console.log('Resyncing clock...')
+  if (fs.existsSync('/etc/init/lamassu-machine.conf')) {
+    var timeResync = cp.exec('bash /opt/apps/machine/lamassu-machine/lib/timeResync.sh')
+    console.log('Resyncing clock...')
+  }
 
   const wifiList = this.state === 'wifiList' && this.wifis
   ? this.wifis

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -416,6 +416,7 @@ Brain.prototype._connectedBrowser = function _connectedBrowser () {
   //  TODO: have to work on this: console.assert(this.state === State.IDLE)
   console.log('connected to browser')
   var timeResync = cp.exec('bash /opt/apps/machine/lamassu-machine/lib/timeResync.sh')
+  console.log('Resyncing clock...')
 
   const wifiList = this.state === 'wifiList' && this.wifis
   ? this.wifis

--- a/lib/timeResync.sh
+++ b/lib/timeResync.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+service ntp stop
+ntpdate -s time.nist.gov
+service ntp start


### PR DESCRIPTION
Upon each periodic reboot or machine start, this forces the machine clock to resync, avoiding `clock skew with lamassu-machine too high` errors.