### PR TITLE
cash dispenser bugfix

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2531,28 +2531,6 @@ Brain.prototype._dispense = function _dispense () {
     })
 }
 
-Brain.prototype.waitForCollection = function waitForCollection () {
-  const txId = this.tx.id
-
-  const checkCollection = () => {
-    const checkState = this.tx.id === txId && this.state === 'fiatComplete'
-
-    if (!checkState) {
-      return clearInterval(timerHandle)
-    }
-
-    this.billDispenser.billsPresent()
-      .then(billsPresent => {
-        if (!billsPresent) {
-          emit('billDispenserCollected')
-          return clearInterval(timerHandle)
-        }
-      })
-  }
-
-  const timerHandle = setInterval(checkCollection, 500)
-}
-
 Brain.prototype._physicalDispense = function _physicalDispense () {
   const fiatCode = this.tx.fiatCode
   const notes = [this.tx.bills[0].provisioned, this.tx.bills[1].provisioned]
@@ -2586,15 +2564,14 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
       const toAddress = coinUtils.formatAddress(tx.cryptoCode, tx.toAddress)
       const displayTx = _.set('toAddress', toAddress, tx)
 
+      emit('billDispenserCollected')
       this._transitionState('fiatComplete', {tx: displayTx})
-      // this.waitForCollection()
     })
     .then(() => pDelay(60000))
     .then(() => {
       const doComplete = this.state === 'fiatComplete' && this.tx.id === txId
 
       if (doComplete) {
-        emit('billDispenserCollected')
         return this._completed()
       }
     })

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2597,8 +2597,6 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
         emit('billDispenserCollected')
         return this._completed()
       }
-
-      throw new Error(`Unknown state ${this.state} !== 'fiatComplete' or ${this.tx.id} !== ${txId}`)
     })
     .catch(err => {
       emit('billDispenserCollected')

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2564,7 +2564,6 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
       const toAddress = coinUtils.formatAddress(tx.cryptoCode, tx.toAddress)
       const displayTx = _.set('toAddress', toAddress, tx)
 
-      emit('billDispenserCollected')
       this._transitionState('fiatComplete', {tx: displayTx})
     })
     .then(() => pDelay(60000))
@@ -2572,6 +2571,7 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
       const doComplete = this.state === 'fiatComplete' && this.tx.id === txId
 
       if (doComplete) {
+        emit('billDispenserCollected')
         return this._completed()
       }
     })


### PR DESCRIPTION
I previously added an exception [here](https://github.com/lamassu/lamassu-machine/pull/116#discussion-diff-193978372R2572)

Actually I'm not sure if it's the proper way to handle this.
If the physical dispense is successful we transit from fiatComplete to goodbye screen but in the middle there is a delay of 1 minute, in which a user can start another transaction.

So in this case it make sense to check for:
```
const doComplete = this.state === 'fiatComplete' && this.tx.id === txId
```

To decide whenever to show or not the goodbye screen.

Anyway I think we should move the `emit('billDispenserCollected')` up before the delay so that we always run that, regardless the above check

