### PR TITLE
lamp scan bay naming fix

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1590,7 +1590,7 @@ Brain.prototype._cancelIdScan = function _cancelIdScan () {
   this.scanner.cancel()
 }
 
-Brain.prototype.hasOldScanBay = function hasNewScanBay () {
+Brain.prototype.hasNewScanBay = function hasNewScanBay () {
   return deviceConfig.brain.hasSsuboard
 }
 


### PR DESCRIPTION
I'm not sure if the correct name should be `hasNewScanBay` or `hasOldScanBay`