### PR TITLE
Puloon dispenser error fix

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1130,7 +1130,6 @@ Brain.prototype.isBlocked = function isBlocked (customer) {
  * @param {object} customer Acting customers
  */
 Brain.prototype.showBlockedCustomer = function showBlockedCustomer (customer) {
-
   /*
    * When doing cashOut just show the blockCustomer screen
    */
@@ -2016,6 +2015,7 @@ Brain.prototype.updateTx = function updateTx (updateTx) {
 
 // Don't wait for server response
 Brain.prototype.fastUpdateTx = function fastUpdateTx (updateTx) {
+  console.log('fastUpdateTx', updateTx)
   const newTx = Tx.update(this.tx, updateTx)
   this.tx = newTx
 
@@ -2547,30 +2547,39 @@ Brain.prototype._fiatError = function _fiatError (err) {
   console.log('fiatError', err)
   const state = this.tx.started ? 'fiatTransactionError' : 'fiatError'
   this._timedState(state)
+  return Promise.reject(err)
 }
 
 Brain.prototype._dispense = function _dispense () {
-  const tx = this.tx
+  return Promise.resolve()
+    .then(() => {
+      // check if dispense was already done
+      if (this.tx.dispense || this.tx.dispenseConfirmed) {
+        throw new Error('Already dispensed')
+      }
 
-  if (tx.dispense || tx.dispenseConfirmed) {
-    const err = new Error('Already dispensed')
-    this._fiatError(err)
-    return Promise.reject(err)
-  }
+      // mark this tx as dispense started
+      return this.updateTx({dispense: true})
+    })
 
-  return this.updateTx({dispense: true})
+    // actual dispense
     .then(() => this._physicalDispense())
+
+    // shit happens
     .catch(err => {
-      console.log('_dispense', err.stack)
-      if (err.statusCode === 570) return this._timedState('outOfCash')
+      console.log('_dispense error', err.stack)
+      if (err.statusCode === INSUFFICIENT_FUNDS_CODE) return this._timedState('outOfCash')
       return this._fiatError(err)
     })
 }
 
 Brain.prototype._physicalDispense = function _physicalDispense () {
   const fiatCode = this.tx.fiatCode
-  const notes = [this.tx.bills[0].provisioned, this.tx.bills[1].provisioned]
   const txId = this.tx.id
+  const notes = [
+    this.tx.bills[0].provisioned,
+    this.tx.bills[1].provisioned
+  ]
 
   if (fiatCode !== this.billDispenser.fiatCode) {
     console.log('Wrong dispenser currency; dispenser: %s, tx: %s',
@@ -2590,9 +2599,18 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
 
       if (dispenseConfirmed) emit('billDispenserDispensed')
 
-      this.fastUpdateTx({bills: this.tx.bills, error: result.error, dispenseConfirmed})
+      // update tx and keep track of the
+      // dispensed bills
+      // and the error code (if any)
+      this.fastUpdateTx({
+        bills: this.tx.bills,
+        error: _.join(' ', _.reject(_.isEmpty, [result.name, result.message, result.err, result.error])),
+        errorCode: result.err,
+        dispenseConfirmed
+      })
 
       if (!dispenseConfirmed) {
+        console.log('dispense error5', result)
         return this._transitionState('outOfCash')
       }
 
@@ -2614,11 +2632,14 @@ Brain.prototype._physicalDispense = function _physicalDispense () {
     .catch(err => {
       emit('billDispenserCollected')
 
+      /*
+       * err -> errorCode
+       * statusCode
+       */
+      console.log('dispense error4', err)
       this.fastUpdateTx({
-        error: _.isEmpty(err.name)
-          ? err.message
-          : _.join(': ', [err.name, err.message]),
-        errorCode: _.defaultTo(null, err.statusCode)
+        error: _.join(' ', _.reject(_.isEmpty, [err.name, err.message, err.err, err.error])),
+        errorCode: err.err
       })
 
       // bounce the error to be catched

--- a/lib/f56/f56-dispenser.js
+++ b/lib/f56/f56-dispenser.js
@@ -37,6 +37,11 @@ BillDispenser.prototype.init = function init (data) {
 
 BillDispenser.prototype.dispense = function dispense (notes) {
   return f56.billCount(notes[0], notes[1])
+    .catch(err => {
+      err.name = 'F56DispenseError'
+      err.statusCode = 570
+      throw err
+    })
 }
 
 BillDispenser.prototype.billsPresent = function billsPresent () {

--- a/lib/mocks/billdispenser.js
+++ b/lib/mocks/billdispenser.js
@@ -55,42 +55,35 @@ BillDispenser.prototype.dispense = function dispense (notes) {
   console.log('Mock dispensing...', notes, self.cassettes)
 
   return pDelay(2000)
-
-    // check if notes is matching any error
     .then(() => {
+      // check if notes is matching any error
       const error = this.matchMockedErrors(notes)
-
       if (!_.isUndefined(error)) {
-        const dispenseErr = new Error(parseInt(error, 16))
-        dispenseErr.name = 'DispenserError'
-
-        throw dispenseErr
+        throw new Error(parseInt(error, 16))
       }
-    })
 
-    // check if balance is available
-    .then(() => {
+      // check if balance is available
       const count = _.min([_.size(notes), _.size(self.cassettes)])
-      for (var i = 0; i < count; i++) {
+      for (let i = 0; i < count; i++) {
         if (notes[i] > self.cassettes[i].count) {
-          const dispenseErr = new Error('not enough cash')
-          dispenseErr.name = 'DispenserError'
-          dispenseErr.statusCode = 570
-
-          throw dispenseErr
+          throw new Error('not enough cash')
         }
       }
-    })
 
-    // return a successful result
-    .then(() => {
-      const result = {
+      // return a successful result
+      return {
         bills: [
           {dispensed: notes[0], rejected: 0},
           {dispensed: notes[1], rejected: 0}
         ]
       }
+    })
 
-      return result
+    // return the error
+    .catch(err => {
+      err.name = 'MockedDispenserError'
+      err.err = err.message
+      err.statusCode = 570
+      throw err
     })
 }

--- a/lib/puloon/puloon-dispenser.js
+++ b/lib/puloon/puloon-dispenser.js
@@ -52,6 +52,11 @@ BillDispenser.prototype.reset = function reset (cassettes) {
 
 BillDispenser.prototype.dispense = function dispense (notes) {
   return this.device.dispense(notes)
+    .catch(err => {
+      err.name = 'PuloonDispenseError'
+      console.log('dispense error3', err)
+      throw err
+    })
 }
 
 BillDispenser.prototype.billsPresent = function billsPresent () {

--- a/lib/puloon/puloonrs232.js
+++ b/lib/puloon/puloonrs232.js
@@ -199,8 +199,8 @@ PuloonRs232.prototype._singleDispense = function _singleDispense (notes, delay) 
         if (err) return reject(err)
         if (res.err) {
           var dispenseErr = new Error(res.err)
-          dispenseErr.name = 'DispenserError'
           dispenseErr.result = res
+          console.log('dispense error1', dispenseErr)
           return reject(dispenseErr)
         }
         resolve(res)
@@ -250,6 +250,8 @@ PuloonRs232.prototype.dispense = function dispense (notes) {
       results.push(e.result)
       var res = aggregateDispensed(results)
       res.err = e.message
+      res.statusCode = 570
+      console.log('dispense error2', res)
       return res
     })
 }


### PR DESCRIPTION
Following my comments here https://trello.com/c/zW9TJcIm/514-dispenser-errors-arent-recorded-in-cashout-tables

I think the issue is that the error logged as:

```
dispenser response
{ code: 82,
  name: 'dispense',
  err: 88,
  bills: [ { dispensed: 0, rejected: 0 }, { dispensed: 0, rejected: 0 } ] }
```

is not correctly propagated