### PR TITLE
Added error handling on pairing errors

### DIFF
--- a/lib/pairing.js
+++ b/lib/pairing.js
@@ -56,6 +56,10 @@ function pair (totemStr, clientCert, connectionInfoPath, model) {
           fs.writeFileSync(connectionInfoPath, JSON.stringify(connectionInfo))
         })
     })
+   .catch(err => {
+     console.log(err)
+     throw new Error("Pairing error - Please make sure you have a stable network connection and that you are using the right QR Code")
+   })
 }
 
 function unpair (connectionInfoPath) {


### PR DESCRIPTION
A invlid QR code was throwing a completly unrelated error because of
invalid chars on the generated URL.

Exceptions are now logged on the console with a friendly error for the
operator.