### PR TITLE
Stop redeem from getting "Out of cash" errors

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2409,7 +2409,9 @@ Brain.prototype._chooseFiat = function _chooseFiat () {
   this.tx = Tx.update(this.tx, {fiatCode: this.fiatCode, direction: 'cashOut'})
 
   const response = this._getFiatButtonResponse()
-  if (response.activeDenominations.isEmpty) return this._timedState('outOfCash')
+
+  // No need to check available cash on redeem. It is already reserved on l-s.
+  if (response.activeDenominations.isEmpty && !this.redeem) return this._timedState('outOfCash')
 
   this._transitionState('chooseFiat', {chooseFiat: response})
   const self = this


### PR DESCRIPTION
Redeem was checking available cash, which was causing a
"Out of cash" error even though the cash is already reserved on l-s.