### PR TITLE
Stop machine from hanging when verifying ID

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2179,11 +2179,11 @@ Brain.prototype._sendCoins = function _sendCoins () {
     buyerAddress: this.tx.toAddress
   })
 
-  if (this.state === 'acceptingBills') this._doSendCoins()
+  this._doSendCoins()
 }
 
 Brain.prototype._doSendCoins = function _doSendCoins () {
-  if (this.state !== 'acceptingBills') return
+  if (this.state !== 'acceptingBills' && this.state !== 'smsVerification') return
   return this._executeSendCoins()
 }
 


### PR DESCRIPTION
Declining to verify ID during a cash_in was causing the machine to
hang indefinedely.