### PR TITLE
Stop overcrediting after ID verification

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -2098,7 +2098,7 @@ Brain.prototype.updateBillScreen = function updateBillScreen () {
 // TODO: clean this up
 Brain.prototype._billRejected = function _billRejected () {
   const self = this
-  if (!_.includes(this.state, BILL_ACCEPTING_STATES)) return
+  if (!_.includes(this.state, BILL_ACCEPTING_STATES) && this.state !== 'smsVerification') return
 
   this.clearBill()
 


### PR DESCRIPTION
The machine was counting a bill that gets returned to the user when
asking for ID verification on cash_in