### PR TITLE
Camera restarts machine fix

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1638,9 +1638,20 @@ Brain.prototype.scanBayLightOff = function scanBayLightOff () {
   emit('scanBayLightOff')
 }
 
+Brain.prototype.handleUnresponsiveCamera = function handleUnresponsiveCamera() {
+  if (!this.scanner.isOpened()) return this._idle()
+
+    this._transitionState('maintenance')
+  let handle = setInterval(() => {
+    if (this.scanner.isOpened()) return
+    clearInterval(handle)
+    this._idle()
+  }, 200)
+}
+
 Brain.prototype._cancelIdScan = function _cancelIdScan () {
   this.startDisabled = true
-  this._bye()
+  this._bye({timeoutHandler: () => {this.handleUnresponsiveCamera()}})
   this.scanner.cancel()
 }
 
@@ -1674,14 +1685,14 @@ Brain.prototype._startAddressScan = function _startAddressScan () {
   }, this.config.qrTimeout)
 }
 
-Brain.prototype._bye = function _bye () {
-  this._timedState('goodbye')
+Brain.prototype._bye = function _bye (opts) {
+  this._timedState('goodbye', opts)
   console.trace('goodbye')
 }
 
 Brain.prototype._cancelScan = function _cancelScan () {
   this.startDisabled = true
-  this._bye()
+  this._bye({timeoutHandler: () => { this.handleUnresponsiveCamera() }})
   this.scanner.cancel()
 }
 
@@ -1802,9 +1813,11 @@ Brain.prototype._timedState = function _timedState (state, opts) {
     return
   }
   const timeout = opts.timeout || 30000
-  const handler = opts.revertState
-    ? function () { self._transitionState(opts.revertState) }
-    : function () { self._idle() }
+  const handler = opts.timeoutHandler 
+    ? opts.timeoutHandler
+    : opts.revertState
+      ? function () { self._transitionState(opts.revertState) }
+      : function () { self._idle() }
 
   this._transitionState(state, opts.data)
   this._screenTimeout(handler, timeout)

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1641,7 +1641,8 @@ Brain.prototype.scanBayLightOff = function scanBayLightOff () {
 Brain.prototype.handleUnresponsiveCamera = function handleUnresponsiveCamera() {
   if (!this.scanner.isOpened()) return this._idle()
 
-    this._transitionState('maintenance')
+  this._transitionState('maintenance')
+  
   let handle = setInterval(() => {
     if (this.scanner.isOpened()) return
     clearInterval(handle)

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -9,6 +9,7 @@ var cancelFlag = false
 
 let opened = false
 let processing = false
+let closing = false
 
 module.exports = {
   config: config,
@@ -63,12 +64,16 @@ function scan (mode, resultCallback, captureCallback) {
 
   function capture () {
     if (cancelFlag) {
-      clearInterval(handle)
-      cam.stop(() => {
-        processing = false
-        opened = false
-        return resultCallback()
-      })
+      if (opened && !closing && !processing) {
+        closing = true
+        clearInterval(handle)
+        cam.stop(() => {
+          processing = false
+          opened = false
+          closing = false
+          return resultCallback()
+        })
+      }
 
       return
     }
@@ -76,13 +81,15 @@ function scan (mode, resultCallback, captureCallback) {
     if (processing) return
     processing = true
 
+    console.log('debug - camera test call')
     cam.capture(function (success) {
+      console.log('debug - camera test response')
       if (!success) return
       var frame = Buffer.from(cam.frameRaw())
       var greyscale = jpg.decompressSync(frame, {format: jpg.FORMAT_GRAY})
 
       captureCallback(width, height, frame, greyscale.data, function (err, result) {
-        if (!err && !result) {
+        if (!err && !result && !cancelFlag) {
           processing = false
           return
         }

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -16,7 +16,8 @@ module.exports = {
   scanPairingCode: scanPairingCode,
   scanMainQR: scanMainQR,
   scanPDF417: scanPDF417,
-  cancel: cancel
+  cancel: cancel,
+  isOpened: isOpened
 }
 
 function setConfig (width, height, cam) {
@@ -38,6 +39,10 @@ function config (_configuration) {
 
 function cancel () {
   cancelFlag = true
+}
+
+function isOpened () {
+  return opened
 }
 
 // resultCallback returns final scan result
@@ -81,9 +86,7 @@ function scan (mode, resultCallback, captureCallback) {
     if (processing) return
     processing = true
 
-    console.log('debug - camera test call')
     cam.capture(function (success) {
-      console.log('debug - camera test response')
       if (!success) return
       var frame = Buffer.from(cam.frameRaw())
       var greyscale = jpg.decompressSync(frame, {format: jpg.FORMAT_GRAY})


### PR DESCRIPTION
Machine could get restarted when canceling scanAddress screen. Because
of the polling on the camera code, cam.stop() could be called multiple
times causing a c error to be thrown.
