### PR TITLE
Fix translation text of buy/sell button

### DIFF
--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -463,7 +463,12 @@ $(document).ready(function () {
   $('.send-coins-sms').click(() => buttonPressed('finishBeforeSms'))
 
   $('.change-language').mousedown(() => {
-    if (_primaryLocales.length === 2) return setLocale(otherLocale())
+    if (_primaryLocales.length === 2) {
+      setLocale(otherLocale())
+      setCryptoBuy(currentCoin)
+      setCryptoSell(currentCoin)
+      return
+    }
     setState('select_locale')
   })
 


### PR DESCRIPTION
When there are only two languages the text was not translating on change.
Previously only changed the text when coming from a languages screen.