### PR TITLE
Fix returnState for smsCompliance at 0$

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1740,9 +1740,7 @@ Brain.prototype._start = function _start () {
   const isCompliant = this.isCompliant(amount)
 
   if (!isCompliant) {
-    return this.smsCompliance({
-      returnState : 'acceptingFirstBill'
-    })
+    return this.smsCompliance()
   }
 
   this._startAddressScan()


### PR DESCRIPTION
The correct flow is now:

```
2018-11-25T07:13:13.540Z LOG new brain state: chooseCoin
2018-11-25T07:13:14.357Z LOG new brain state: registerPhone
2018-11-25T07:13:16.128Z LOG new brain state: waiting
2018-11-25T07:13:16.635Z LOG new brain state: securityCode
2018-11-25T07:13:18.362Z LOG new brain state: scanAddress
```