### PR TITLE
Update reboot script to handle ssuboard systems

### DIFF
--- a/deploy/commands/reboot.js
+++ b/deploy/commands/reboot.js
@@ -4,11 +4,14 @@ var cp = require('child_process');
 var async = require('./async');
 var report = require('./report').report;
 
-var hardwareCode = process.argv[2] || 'N7G1';
+const hardwareCode = process.argv[2].toLowerCase();
 
-var restartCommand = hardwareCode === 'N7G1' ?
- 'poweroff -d 2' :
- 'restart lamassu-machine; killall chromium-browser';
+let restartCommand = null
+if (hardwareCode === 'aaeon')
+  restartCommand = 'restart lamassu-machine; killall chromium-browser'
+else if (hardwareCode === 'ssuboard')
+  restartCommand = 'supervisorctl restart all'
+else restartCommand = ''
 
 
 report(null, 'started', function() {});

--- a/deploy/commands/reboot.js
+++ b/deploy/commands/reboot.js
@@ -10,7 +10,7 @@ let restartCommand = null
 if (hardwareCode === 'aaeon')
   restartCommand = 'restart lamassu-machine; killall chromium-browser'
 else if (hardwareCode === 'ssuboard')
-  restartCommand = 'supervisorctl restart all'
+  restartCommand = 'supervisorctl restart lamassu-machine lamassu-browser'
 else restartCommand = ''
 
 

--- a/lib/trader.js
+++ b/lib/trader.js
@@ -64,8 +64,17 @@ Trader.prototype.syncLogs = function syncLogs () {
     .then(data => data.body)
   // Delete log files that are two or more days old
     .then(() => {
-      let today = new Date()
-      return logs.removeLogFiles(today.setDate(today.getDate() - 2))
+      const twoDaysAgo = (() => {
+        let date = new Date()
+
+	// Notice that `setDate()` can take negative values. So if you'd take
+	// -2 days on the 1st of April you'd get the 30th of March. Several
+	// examples can be seen at: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate#Using_setDate()
+        date.setDate(date.getDate() - 2)
+	return date
+      })()
+
+      return logs.removeLogFiles(twoDaysAgo)
     })
   // Load unseen logs to send
     .then(logs.queryNewestLogs)

--- a/lib/trader.js
+++ b/lib/trader.js
@@ -74,7 +74,7 @@ Trader.prototype.syncLogs = function syncLogs () {
 	return date
       })()
 
-      return logs.removeLogFiles(twoDaysAgo).then(it)
+      return logs.removeLogFiles(twoDaysAgo).then(() => it)
     })
   // Load unseen logs to send
     .then(logs.queryNewestLogs)

--- a/lib/trader.js
+++ b/lib/trader.js
@@ -63,7 +63,7 @@ Trader.prototype.syncLogs = function syncLogs () {
   this.request({ path: '/logs', method: 'get' })
     .then(data => data.body)
   // Delete log files that are two or more days old
-    .then(() => {
+    .then((it) => {
       const twoDaysAgo = (() => {
         let date = new Date()
 
@@ -74,7 +74,7 @@ Trader.prototype.syncLogs = function syncLogs () {
 	return date
       })()
 
-      return logs.removeLogFiles(twoDaysAgo)
+      return logs.removeLogFiles(twoDaysAgo).then(it)
     })
   // Load unseen logs to send
     .then(logs.queryNewestLogs)


### PR DESCRIPTION
This reboot script will now handle ssuboard's lamassu-machine and lamassu-browser reboot through `supervirsorctl`.
Also added a readability improvement, regarding date handling, that was missing from #267.
