### PR TITLE
Adjust the update configuration of bill dispenser and validator

### DIFF
--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -53,6 +53,8 @@ function installDeviceConfig (cb) {
     // Pretty-printing the new configuration to retain its usual form.
     const adjustedDeviceConfig = JSON.stringify(newDeviceConfig, null, 2)
     fs.writeFileSync(currentDeviceConfigPath, adjustedDeviceConfig)
+
+    cb()
   }
   catch (err) {
     cb(err)

--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -52,10 +52,7 @@ function installDeviceConfig (cb) {
 
     // Pretty-printing the new configuration to retain its usual form.
     const adjustedDeviceConfig = JSON.stringify(newDeviceConfig, null, 2)
-    fs.writeFileSync(newDeviceConfigPath, adjustedDeviceConfig)
-
-    const cmd = 'cp /tmp/extract/package/subpackage/hardware/' + hardwareCode + '/device_config.json /opt/apps/machine/lamassu-machine'
-    command(cmd, cb)
+    fs.writeFileSync(currentDeviceConfigPath, adjustedDeviceConfig)
   }
   catch (err) {
     cb(err)


### PR DESCRIPTION
The update package might carry invalid configurations for the fields related with the bill dispenser and bill validator. This will consume their current working configurations into the update's `package_config.json` file before deploying it in the system.