### PR TITLE
Identify F56 error code in message log

### DIFF
--- a/lib/dispense-generator.js
+++ b/lib/dispense-generator.js
@@ -37,7 +37,7 @@ const dispenseGenerator = function * dispenseGenerator (notes, tx, txId) {
   // and the error code (if any)
   const fastUpdateTxEventDataErr = {
     error: _.join(' ', _.reject(_.isEmpty, [error.name, error.message, error.err, error.error])),
-    errorCode: error.err
+    errorCode: error.statusCode,
   }
   const fastUpdateTxEventData = _.extend(
     { bills: tx.bills, dispenseConfirmed },

--- a/lib/f56/f56-rs232.js
+++ b/lib/f56/f56-rs232.js
@@ -96,8 +96,10 @@ function billsPresent () {
   return request(command)
     .then(res => {
       if (res[0] === 0xf0) {
-        console.error('F56 Error')
+        const errorCode = res.slice(3,5)
+        console.error(`F56 Error with code ${prettyHex(errorCode)}`)
         console.error(prettyHex(res))
+
         throw new Error('F56 Error')
       }
 

--- a/lib/f56/f56-rs232.js
+++ b/lib/f56/f56-rs232.js
@@ -67,7 +67,8 @@ function billCount (c1, c2) {
     .then(command => request(command))
     .then(res => {
       if (res[0] === 0xf0) {
-        console.error('F56 Error')
+        const errorCode = res.slice(3,5)
+        console.error(`F56 Error with code ${prettyHex(errorCode)}`)
         console.error(prettyHex(res))
         throw new Error('F56 Error')
       }


### PR DESCRIPTION
This should now propagate the `statusCode` and properly log the F56 protocol error code. According to the F56 D-LEVEL spec, the error code lives at bytes 3 and 4 in the response frame.