### PR TITLE
On batch cash-out, wait for user to collect the notes before delivering next batches

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -500,7 +500,10 @@ Brain.prototype.processDispenseGeneratorAction = function processDispenseGenerat
               actionEmitter.emit('billCollected', { action: 'dispensed', value: evt.value })
             }
           })
-          .catch(err => actionEmitter.emit('billDispenser', { action: 'failure', value: err }))
+          .catch((err) => {
+            clearInterval(interval)
+            actionEmitter.emit('billDispenser', { action: 'failure', value: err })
+          })
       },
       1000, event)
 

--- a/lib/brain.js
+++ b/lib/brain.js
@@ -491,6 +491,19 @@ Brain.prototype.processDispenseGeneratorAction = function processDispenseGenerat
         .catch(err => actionEmitter.emit('billDispenser', { action: 'failure', value: err }))
       return
     case 'billDispenserDispensed':
+      const self = this
+      const interval = setInterval((evt) => {
+        self.billDispenser.billsPresent()
+          .then((billsArePresent) => {
+            if (!billsArePresent) {
+              clearInterval(interval)
+              actionEmitter.emit('billCollected', { action: 'dispensed', value: evt.value })
+            }
+          })
+          .catch(err => actionEmitter.emit('billDispenser', { action: 'failure', value: err }))
+      },
+      1000, event)
+
       return
     case 'billDispenserCollected':
       return

--- a/lib/dispense-generator.js
+++ b/lib/dispense-generator.js
@@ -85,6 +85,11 @@ module.exports = function (notes, tx, txId) {
   g.next()
 
   actionEmitter.on('billDispenser', event => {
+    if (event.action === 'failure')
+      g.next(event)
+    else emit({action: 'billDispenserDispensed', value: event.value })
+  })
+  actionEmitter.on('billCollected', event => {
     g.next(event)
   })
 }

--- a/lib/dispense-generator.js
+++ b/lib/dispense-generator.js
@@ -17,6 +17,7 @@ const dispenseGenerator = function * dispenseGenerator (notes, tx, txId) {
         error = yielded.value
         break
       }
+      console.log(`Dispensed amount: ${yielded.value}`)
       result.push(yielded.value)
     }
   }
@@ -84,12 +85,19 @@ module.exports = function (notes, tx, txId) {
   let g = dispenseGenerator(notes, tx, txId)
   g.next()
 
-  actionEmitter.on('billDispenser', event => {
-    if (event.action === 'failure')
+  if (notes.length > 1) {
+    actionEmitter.on('billDispenser', event => {
+      if (event.action === 'failure')
+        g.next(event)
+      else emit({action: 'billDispenserDispensed', value: event.value })
+    })
+    actionEmitter.on('billCollected', event => {
       g.next(event)
-    else emit({action: 'billDispenserDispensed', value: event.value })
-  })
-  actionEmitter.on('billCollected', event => {
-    g.next(event)
-  })
+    })
+  }
+  else {
+    actionEmitter.on('billDispenser', event => {
+      g.next(event)
+    })
+  }
 }


### PR DESCRIPTION
The changes introduced here will wait for the use to collect a batch of notes before delivering the next one. Previously, all batches would be delivered one after the other without waiting for the user to collect them.