### PR TITLE
Add small delay on terms and conditions

### DIFF
--- a/lib/brain.js
+++ b/lib/brain.js
@@ -1656,7 +1656,7 @@ Brain.prototype.startScreen = function startScreen () {
   // check if terms screen is enabled
   // and user still need to accept terms
   if (this.mustAcceptTerms()) {
-    return this._timedState('termsScreen')
+    return this._transitionState('termsScreen')
   }
 
   if (direction === 'cashOut') return this._chooseFiat()

--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -918,7 +918,7 @@ function startPage (text) {
       totalPages = Math.ceil(textHeightQuantity / scrollSize)
       updatePageCounter()
     }
-  })
+  }, 100)
 }
 
 function updatePageCounter () {

--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -17,6 +17,8 @@ var isTwoWay = null
 var isRTL = false
 var two = null
 var cryptomatModel = null
+var termsConditionsTimeout = null
+var T_C_TIMEOUT = 30000
 
 var fiatCode = null
 var locale = null
@@ -887,10 +889,31 @@ function setTermsScreen (data) {
   startPage(data.text)
   $screen.find('.js-terms-accept-button').html(data.accept)
   $screen.find('.js-terms-cancel-button').html(data.cancel)
+  setTermsConditionsTimeout()
+}
+
+function clearTermsConditionsTimeout () {
+  clearTimeout(termsConditionsTimeout)
+}
+
+function setTermsConditionsTimeout () {
+  termsConditionsTimeout = setTimeout(function () {
+    console.log('is this going on?')
+    if (currentState === 'terms_screen') {
+      console.log('and this?')
+      buttonPressed('idle')
+    }
+  }, T_C_TIMEOUT)
+}
+
+function resetTermsConditionsTimeout () {
+  clearTermsConditionsTimeout()
+  setTermsConditionsTimeout()
 }
 
 // click page up button
 function scrollUp () {
+  resetTermsConditionsTimeout()
   const div = document.getElementById('js-terms-text-div')
   if (currentPage !== 0) {
     currentPage -= 1
@@ -927,6 +950,7 @@ function updatePageCounter () {
 
 // click page up button
 function scrollDown () {
+  resetTermsConditionsTimeout()
   const div = document.getElementById('js-terms-text-div')
   if (!(currentPage * scrollSize + scrollSize > textHeightQuantity && currentPage !== 0)) {
     currentPage += 1


### PR DESCRIPTION
Jquery.html() has a small delay on mounting the text to the dom.
This is barely noticeble in dev but in prod we're getting failures