### PR TITLE
Extend scanner timeout

### DIFF
--- a/software_config.json
+++ b/software_config.json
@@ -64,6 +64,6 @@
     }
   },
   "scanner": {
-    "timeout": 30000
+    "timeout": 120000
   }
 }


### PR DESCRIPTION
This had been present in a DO version of this file used in the build process, but our repo's version should be used instead.