### PR TITLE
deploy package changes

### DIFF
--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -32,6 +32,7 @@ function installDeviceConfig (cb) {
     }
     if (currentDeviceConfig.billValidator) {
       newDeviceConfig.billValidator.deviceType = currentDeviceConfig.billValidator.deviceType
+      newDeviceConfig.billValidator.rs232.device = currentDeviceConfig.billValidator.rs232.device
     }
 
     // Pretty-printing the new configuration to retain its usual form.

--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -6,7 +6,7 @@ const cp = require('child_process');
 const report = require('./report').report;
 
 const hardwareCode = process.argv[2];
-const TIMEOUT = 300000;
+const TIMEOUT = 600000;
 const applicationParentFolder = hardwareCode === 'aaeon' ? '/opt/apps/machine' : '/opt'
 
 function command(cmd, cb) {
@@ -31,7 +31,7 @@ function installDeviceConfig (cb) {
       newDeviceConfig.billDispenser.device = currentDeviceConfig.billDispenser.device
     }
     if (currentDeviceConfig.billValidator) {
-      newDeviceConfig.billValidator.rs232.device = currentDeviceConfig.billValidator.rs232.device
+      newDeviceConfig.billValidator.deviceType = currentDeviceConfig.billValidator.deviceType
     }
 
     // Pretty-printing the new configuration to retain its usual form.

--- a/deploy/reboot-uni/updatescript.js
+++ b/deploy/reboot-uni/updatescript.js
@@ -10,7 +10,7 @@ var TIMEOUT = 10000;
 let restartCommand = null
 if (hardwareCode === 'aaeon')
   restartCommand = 'restart lamassu-machine; killall chromium-browser'
-else if (hardwareCode === 'ssuboard')
+else if (hardwareCode === 'ssuboard' || hardwareCode === 'upboard')
   restartCommand = 'supervisorctl restart lamassu-machine lamassu-browser'
 else restartCommand = ''
 


### PR DESCRIPTION
We should preserve both the validator type (*i.e.*, `cashflowSc`) as well as its mount point during updates.