### PR TITLE
Remove mock-cam from package build

### DIFF
--- a/deploy/codebase/build.sh
+++ b/deploy/codebase/build.sh
@@ -48,7 +48,6 @@ cp -r $MACHINE_DIR/lib $TARGET_MACHINE_DIR
 cp -a $MACHINE_DIR/exec $TARGET_MACHINE_DIR
 cp $MACHINE_DIR/bin/lamassu-machine $TARGET_MACHINE_DIR/bin
 cp $MACHINE_DIR/bin/cam.js $TARGET_MACHINE_DIR/bin
-cp $MACHINE_DIR/bin/mock-cam.js $TARGET_MACHINE_DIR/bin
 
 cp -r $MACHINE_DIR/ui $TARGET_MACHINE_DIR
 $MACHINE_DIR/node_modules/.bin/copy-node-modules $MACHINE_DIR $TARGET_MACHINE_DIR


### PR DESCRIPTION
Otherwise, error as mock-cam.js had been removed.