### PR TITLE
Fixed a (probable) bug in tx limit check at sell.

### DIFF
--- a/lib/tx.js
+++ b/lib/tx.js
@@ -124,7 +124,7 @@ function computeCashOut (tx, cassettes, virtualCassettes, txLimit) {
   const denominationIsAvailable = denom =>
     !!BillMath.makeChange(cassettes, tx.fiat.add(denom))
 
-  const denominationUnderLimit = denom => BN(denom).lte(txLimit)
+  const denominationUnderLimit = denom => tx.fiat.add(denom).lte(txLimit)
 
   const denominationIsActive = _.overEvery([denominationUnderLimit, denominationIsAvailable])
   const denoms = _.union(virtualCassettes, _.map(_.get('denomination'), cassettes))


### PR DESCRIPTION
Tx limit should be checked against the whole amount instead of a single bill. Let me know if this is not a bug. At least it looks like it, when txLimit is set, it just limits the bills available but doesn't limit the maximum amount. I.e. when txLimit is 40 and 20+50 euro bills are available, the 50€ button is disabled but user may click 20€ button any number of times, exceeding 40 euro.

This patch makes the limit behave so that the limit is imposed on the whole amount so that when txLimit is 40, maximum of 40€ may withdrawn.