### PR TITLE
Mock camera improvements

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,6 +32,7 @@ exports.loadConfig = function (commandLine) {
     const mockCamConfig = {
       pairingData: config.mockPair,
       qrData: config.brain.mockCryptoQR,
+      qrDataSource: config.brain.mockQrSource,
       pk: config.brain.mockPK,
       pdf417Data: pdf417Data,
       fakeLicense: fakeLicense

--- a/lib/mocks/scanner.js
+++ b/lib/mocks/scanner.js
@@ -1,6 +1,8 @@
 const _ = require('lodash/fp')
 const Pdf417Parser = require('../compliance/parsepdf417')
 const coinUtils = require('../coins/utils')
+const fs = require('fs')
+const path = require('path')
 
 module.exports = {
   config,
@@ -37,7 +39,11 @@ function scanPairingCode (callback) {
 function scanMainQR (cryptoCode, callback) {
   _cancelCb = callback
   handle = setTimeout(function () {
-    var resultStr = mockData.qrData[cryptoCode]
+    if (!mockData.qrDataSource) {
+      var resultStr = mockData.qrData[cryptoCode]
+    } else {
+      resultStr = fs.readFileSync(path.join(__dirname, '../../', mockData.qrDataSource))
+    }
     const network = 'main'
     try {
       callback(null, coinUtils.parseUrl(cryptoCode, network, resultStr))

--- a/lib/mocks/scanner.js
+++ b/lib/mocks/scanner.js
@@ -22,6 +22,7 @@ let _cancelCb = null
 let mockData = null
 let handle
 let camera = null
+let opened = false
 
 function config (_configuration) {
   configuration = _configuration
@@ -30,15 +31,19 @@ function config (_configuration) {
 }
 
 function scanPairingCode (callback) {
+  opened = true
   _cancelCb = callback
   handle = setTimeout(function () {
+    opened = false
     callback(null, mockData.pairingData)
   }, cbTimeout)
 }
 
 function scanMainQR (cryptoCode, callback) {
+  opened = true
   _cancelCb = callback
   handle = setTimeout(function () {
+    opened = false
     if (!mockData.qrDataSource) {
       var resultStr = mockData.qrData[cryptoCode]
     } else {
@@ -54,8 +59,10 @@ function scanMainQR (cryptoCode, callback) {
 }
 
 function scanPK (callback) {
+  opened = true
   _cancelCb = callback
   handle = setTimeout(function () {
+    opened = false
     var resultStr = mockData.pk
     if (mockData.pk) {
       return callback(null, resultStr)
@@ -66,37 +73,44 @@ function scanPK (callback) {
 }
 
 function scanPDF417 (callback) {
+  opened = true
   _cancelCb = callback
 
   const pdf417Data = mockData.pdf417Data
   handle = setTimeout(function () {
+    opened = false
     callback(null, Pdf417Parser.parse(pdf417Data))
   }, cbTimeout)
 }
 
 function scanPhotoCard (callback) {
+  opened = true
   _cancelCb = callback
 
   const photoData = mockData.fakeLicense
   handle = setTimeout(function () {
+    opened = false
     callback(null, photoData)
   }, cbTimeout)
 }
 
 function scanFacephoto (callback) {
+  opened = true
   _cancelCb = callback
 
   const photoData = mockData.fakeLicense
   handle = setTimeout(function () {
+    opened = false
     callback(null, photoData)
   }, cbTimeout)
 }
 
 function isOpened () {
-  return true
+  return opened
 }
 
 function cancel () {
+  opened = false
   clearTimeout(handle)
   camera && camera.closeCamera()
   if (_cancelCb) _cancelCb()


### PR DESCRIPTION
This PR has two related but distinct patches:

* Allow reading mock camera QR code data dynamically from a file or FIFO instead of static content. Makes it easier to debug UI state transformations because app is not needed to restart while testing many QR codes.
* Make mock camera behave more like a real camera by keeping the "opened" state consistent. Without this patch `isOpened()` returns always true, making some operations to fail on mock camera.