### PR TITLE
Add UI error logging for cases when no unique view is found

### DIFF
--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -777,6 +777,7 @@ function setScreen (newScreen, oldScreen) {
   }
 
   var newView = $('.' + newScreen + '_state')
+  if (newView.length !== 1) console.log('FATAL: ' + newView.length + ' screens found of class ' + newScreen + '_state')
 
   $('.viewport').removeClass('viewport-active')
   newView.addClass('viewport-active')


### PR DESCRIPTION
In case there is 0 or more than one possible views matching the name of a new view, error message is printed on JS console. This makes it easier to debug the UI because you'll get an error and not just a white screen only.