### PR TITLE
Fix resolution for front facing camera

### DIFF
--- a/hardware/codebase/ssuboard/device_config.json
+++ b/hardware/codebase/ssuboard/device_config.json
@@ -22,7 +22,7 @@
     "device": "/dev/video-front",
     "facephoto": {
       "width": 1280,
-      "height": 960,
+      "height": 1024,
       "threshold": 20,
       "minFaceSize": 180
     }


### PR DESCRIPTION
1280x960 is not a supported resolution for this camera