### PR TITLE
fix: moved <totem-from-admin> param on l-m execution to the right place

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ In second terminal window:
 
 ```
 node bin/lamassu-machine --mockBillValidator --mockBillDispenser --mockCam \
---mockPair --devBoard '<totem-from-admin>'
+--mockPair '<totem-from-admin>' --devBoard
 ```
 
 **IMPORTANT**: Make sure to use single quotes and not double quotes, or the shell will mess up the totem.


### PR DESCRIPTION
Fixed the lamassu-machine first run command by moving the totem string to the right location, which is after --mockPair