### PR TITLE
chore: increase log archive size

### DIFF
--- a/deploy/purge-logs/updatescript.js
+++ b/deploy/purge-logs/updatescript.js
@@ -9,9 +9,9 @@ var TIMEOUT = 10000;
 
 let purgeCommand = null
 if (hardwareCode === 'aaeon')
-  purgeCommand = 'rm /var/lib/lamassu-machine/log/*; rm /var/lib/lamassu-machine/tx-db/*'
+  purgeCommand = 'rm /var/lib/lamassu-machine/log/*; rm /var/lib/lamassu-machine/tx-db/*; rm /var/log/upstart/lamassu-*.log.*; truncate -s 0 /var/log/upstart/lamassu-*.log'
 else if (hardwareCode === 'ssuboard' || hardwareCode === 'upboard')
-  purgeCommand = 'rm /opt/lamassu-machine/data/log/*; rm /opt/lamassu-machine/data/tx-db/*'
+  purgeCommand = 'rm /opt/lamassu-machine/data/log/*; rm /opt/lamassu-machine/data/tx-db/*; rm /var/log/supervisor/lamassu-*.*.log.*; truncate -s 0 /var/log/supervisor/lamassu-*.*.log'
 else purgeCommand = ''
 
 function command(cmd, cb) {

--- a/deploy/show_log/updatescript.js
+++ b/deploy/show_log/updatescript.js
@@ -34,7 +34,7 @@ function tailFile(file, cb) {
     fs.stat(file, function(err, stats) {
       if (err) return report(err, null, cb);
       var opts = {
-        start: stats.size - 256000
+        start: stats.size - 1024000
       };
 
       var httpsOptions = {


### PR DESCRIPTION
Clear all logs with `purge-logs` to set a baseline and reduce log archive size. (Helpful as `lamassu-browser` and others don't have timestamps, thus we should clear old entries.)

Increase log archive size for `show_log`, as we've run into longer archives that are corrupted upon upload.