### PR TITLE
Mock camera fixes

### DIFF
--- a/lib/mocks/scanner.js
+++ b/lib/mocks/scanner.js
@@ -45,15 +45,18 @@ function scanMainQR (cryptoCode, callback) {
   handle = setTimeout(function () {
     opened = false
     if (!mockData.qrDataSource) {
-      var resultStr = mockData.qrData[cryptoCode]
+      forward(null, mockData.qrData[cryptoCode])
     } else {
-      resultStr = fs.readFileSync(path.join(__dirname, '../../', mockData.qrDataSource))
+      fs.readFile(path.join(__dirname, '../../', mockData.qrDataSource), forward)
     }
-    const network = 'main'
-    try {
-      callback(null, coinUtils.parseUrl(cryptoCode, network, resultStr))
-    } catch (error) {
-      callback(error)
+
+    function forward (err, resultStr) {
+      const network = 'main'
+      try {
+        callback(null, coinUtils.parseUrl(cryptoCode, network, resultStr))
+      } catch (error) {
+        callback(error)
+      }
     }
   }, cbTimeout)
 }

--- a/lib/mocks/scanner.js
+++ b/lib/mocks/scanner.js
@@ -113,6 +113,6 @@ function cancel () {
   opened = false
   clearTimeout(handle)
   camera && camera.closeCamera()
-  if (_cancelCb) _cancelCb()
+  if (_cancelCb) _cancelCb(null, null)
   _cancelCb = null
 }


### PR DESCRIPTION
Mock camera cancellation callback should return *null*s instead of *undefined* to behave identically as the real camera.

Also, changed reading of mock QR codes to read file async to support reading from FIFOs or other blocking devices so that cancellation works, too.