### PR TITLE
fix: support v7.4.9 update process

### DIFF
--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -62,7 +62,7 @@ function updateSupervisor (cb) {
 function updateAcpChromium (cb) {
   if (hardwareCode !== 'aaeon') return cb()
 
-  cp.exec(`chromium-browser --version | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//k'`, {timeout: TIMEOUT}, (err, stdout) => {
+  cp.exec(`chromium-browser --version | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'`, {timeout: TIMEOUT}, (err, stdout) => {
     if (err) {
       console.log('failure getting chromim version', err)
       throw err
@@ -74,7 +74,6 @@ function updateAcpChromium (cb) {
       async.apply(command, 'apt update || apt install chromium-browser -y'),
       async.apply(command, `cp ${path}/sencha-chrome.conf /home/iva/.config/upstart/` ),
       async.apply(command, `cp ${path}/start-chrome /home/iva/` ),
-      async.apply(command, 'killall chromium-browser && killall start-chrome'),
     ], function(err) {
       if (err) throw err;
       cb()

--- a/deploy/reboot-749/build.sh
+++ b/deploy/reboot-749/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+SUB_DIR=reboot-749
+SCRIPT_DIR=$(dirname $0)
+
+EXPORT_ROOT=${1-$LAMASSU_EXPORT}
+
+if [ -z "$EXPORT_ROOT" ]
+  then
+    echo "Builds an update package file for rebooting l-m and browser across aaeon-acp and ssuboard."
+    echo -e "\nUsage:"
+    echo -e "build <target directory>\n"
+    exit 1
+ fi
+
+MACHINE_DIR=$SCRIPT_DIR/../..
+EXPORT_BASE=$EXPORT_ROOT/$SUB_DIR
+EXPORT_DIR=$EXPORT_BASE/package
+UPDATESCRIPT=$SCRIPT_DIR/updatescript.js
+rm -rf $EXPORT_DIR
+mkdir -p $EXPORT_DIR
+
+# Needed for update script on target device
+cp $MACHINE_DIR/node_modules/async/lib/async.js $EXPORT_DIR
+cp $SCRIPT_DIR/../report.js $EXPORT_DIR
+cp $UPDATESCRIPT $EXPORT_DIR
+
+echo "Building..."
+node $SCRIPT_DIR/../build.js $EXPORT_BASE
+rm -rf $EXPORT_DIR
+echo "Complete."

--- a/deploy/reboot-749/updatescript.js
+++ b/deploy/reboot-749/updatescript.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var cp = require('child_process');
+var async = require('./async');
+var report = require('./report').report;
+
+const hardwareCode = process.argv[2].toLowerCase();
+var TIMEOUT = 10000;
+
+let restartCommand = null
+if (hardwareCode === 'aaeon')
+  restartCommand = 'restart lamassu-machine; killall chromium-browser; killall start-chrome'
+else if (hardwareCode === 'ssuboard' || hardwareCode === 'upboard')
+  restartCommand = 'supervisorctl restart lamassu-machine lamassu-browser'
+else restartCommand = ''
+
+function command(cmd, cb) {
+  cp.exec(cmd, {timeout: TIMEOUT}, function(err) {
+    cb(err);
+  });
+}
+
+async.series([
+
+  async.apply(command, restartCommand),
+  async.apply(report, null, 'finished.')
+], function(err) {
+  if (err) throw err;
+});


### PR DESCRIPTION
`chromium-browser` and `start-chrome` don't reliably restart as part of the codebase update. Moving to a new reboot script instead.