### PR TITLE
fix: preserve cryptomatModel upon update

### DIFF
--- a/deploy/codebase/updateinit.js
+++ b/deploy/codebase/updateinit.js
@@ -83,6 +83,9 @@ function installDeviceConfig (cb) {
     const currentDeviceConfig = require(currentDeviceConfigPath)
     const newDeviceConfig = require(newDeviceConfigPath)
 
+    if (currentDeviceConfig.cryptomatModel) {
+      newDeviceConfig.cryptomatModel = currentDeviceConfig.cryptomatModel
+    }
     if (currentDeviceConfig.billDispenser && newDeviceConfig.billDispenser) {
       newDeviceConfig.billDispenser.model = currentDeviceConfig.billDispenser.model
       newDeviceConfig.billDispenser.device = currentDeviceConfig.billDispenser.device


### PR DESCRIPTION
Fixes issue with updating the Douro II, where `cryptomatModel` was overwritten, as lamassu-watchdog only conveys the platform on the ssuboard, rather than platform + model as it does with UPboards.

For UPboards, a further safeguard against overwriting.