### PR TITLE
fix: NAB - NAD

### DIFF
--- a/lib/f56/bills.js
+++ b/lib/f56/bills.js
@@ -276,7 +276,7 @@ module.exports = {
     },
     polymer: false
   },
-  NAB: {
+  NAD: {
     thickness: 0x0c,
     lengths: {
       10: [0x86, 0x7c],


### PR DESCRIPTION
Corrected namibian dollar on bills.js from NAB to NAD