### PR TITLE
Draft: printer: add wallet address to wallet printout

### DIFF
--- a/lib/printer/nippon.js
+++ b/lib/printer/nippon.js
@@ -279,6 +279,16 @@ function printWallet (wallet, printerCfg, code) {
         cmd.push([0x1b, 0x71, 0x06, 0x03, 0x04, 0x05, qrcodeLenRemainder, qrcodeLen])
         cmd.push(wallet.privateKey)
 
+        cmd.push(lineFeed)
+
+        cmd.push('Address:')
+        cmd.push(lineFeed)
+
+        cmd.push(`  ${wallet.publicAddress.slice(0, Math.ceil(wallet.publicAddress.length / 2))}`)
+        cmd.push(lineFeed)
+
+        cmd.push(`  ${wallet.publicAddress.slice(Math.ceil(wallet.publicAddress.length / 2))}`)
+
         // New lines and cut
         cmd.push(finalLineFeed)
         cmd.push(fullCut)


### PR DESCRIPTION
It is currently impossible to correlate private key printouts to receipt printouts, because there is no other information besides the private key on the former.

Adding the wallet address to the wallet printout is a natural way of alleviating this.

Draft: This would also need to be done for the `zebra` printer.