### PR TITLE
fix: ignore `disable()` before successful startup

### DIFF
--- a/lib/hcm2/hcm2.js
+++ b/lib/hcm2/hcm2.js
@@ -9,7 +9,7 @@ const pDelay = require('delay')
 const BN = require('../bn')
 
 const testNotes = 'false'
-const LDN = 'HCM2_01'
+let LDN = 'HCM2_01'
 
 let ID = 0
 const getID = () => {
@@ -138,6 +138,16 @@ Hcm2.prototype.registerUSB = function registerUSB () {
       body :
       bodyOrThrow('registerUSB', body)
   )
+}
+
+Hcm2.prototype.getRegistered = function getRegistered (initial) {
+  return rpc_call("ac/configure/getRegistered.cgi", {
+    method: 'getRegistered',
+    //description: 'Scans all USB devices attached to the host and automatically registers the ARCA-supported ones',
+  })
+  .then(result => {
+    LDN = result[0].ldn
+  })
 }
 
 Hcm2.prototype.getFirmwareVersion = function getFirmwareVersion (initial) {
@@ -430,6 +440,7 @@ Hcm2.prototype.retractEscrow = function retractEscrow () {
 Hcm2.prototype.run = function run (cb, { recyclers }) {
   this.initializing = true
   return this.registerUSB()
+    .then(() => this.getRegistered())
     .then(() => this.getFirmwareVersion())
     .then(() => this.getInfo())
     .then(() => this.getBanknoteInfo(recyclers))

--- a/lib/hcm2/hcm2.js
+++ b/lib/hcm2/hcm2.js
@@ -178,7 +178,7 @@ Hcm2.prototype.getInfo = function getInfo () {
       _.map(_.flow(
         _.replace(new RegExp('NoteId', 'g'), ''),
         _.split(':'),
-        ([nodeId, denomCode]) => ({ noteId, denomCode })
+        ([noteId, denomCode]) => ({ noteId, denomCode })
       )),
     )(reply)
     return reply

--- a/lib/hcm2/hcm2.js
+++ b/lib/hcm2/hcm2.js
@@ -96,14 +96,15 @@ const Hcm2 = function (config) {
   EventEmitter.call(this)
   this.config = config
 
+  this.initializing = false
+  this.initialized = false
+
   // Bill validator variables
   this.fiatCode = null
   this.denominations = null
   this.denomCodeSettings = null
 
   // Bill dispenser variables
-  this.initializing = null
-  this.initialized = null
   this.recyclers = null
   this.dispenseLimit = 200
 
@@ -442,6 +443,7 @@ Hcm2.prototype.retractEscrow = function retractEscrow () {
 }
 
 Hcm2.prototype.run = function run (cb, { recyclers }) {
+  this.initializing = true
   return this.registerUSB()
     .then(() => this.getFirmwareVersion())
     .then(() => this.getInfo())
@@ -449,8 +451,13 @@ Hcm2.prototype.run = function run (cb, { recyclers }) {
     .then(() => this.setDenomination())
     .then(() => this.setInfo())
     .then(() => this.reset('full'))
-    .then(() => cb(null))
+    .then(() => {
+      this.initialized = true
+      this.initializing = false
+      cb(null)
+    })
     .catch(err => {
+      this.initializing = false
       console.log(err)
       cb(err)
     })
@@ -463,7 +470,7 @@ Hcm2.prototype.reenable = function reenable () {
 Hcm2.prototype.enable = function enable () {}
 
 Hcm2.prototype.disable = function disable () {
-  return this.closeShutter()
+  return this.initialized ? this.closeShutter() : Promise.resolve()
 }
 
 Hcm2.prototype.reject = function reject () {

--- a/lib/hcm2/hcm2.js
+++ b/lib/hcm2/hcm2.js
@@ -175,8 +175,11 @@ Hcm2.prototype.getInfo = function getInfo () {
     this.denomCodeSettings = _.flow(
       _.get(['DenomCodeSettings']),
       _.split(','),
-      _.map(_.flow(_.replace(new RegExp('NoteId', 'g'), ''), _.split(':'))),
-      _.fromPairs,
+      _.map(_.flow(
+        _.replace(new RegExp('NoteId', 'g'), ''),
+        _.split(':'),
+        ([nodeId, denomCode]) => ({ noteId, denomCode })
+      )),
     )(reply)
     return reply
   })
@@ -222,25 +225,7 @@ Hcm2.prototype.setDenomination = function setDenomination () {
     //description: 'Assign Denomination code to each of Note IDs.',
     params: {
       LDN,
-      noteIDs: [
-        { noteId: '1', denomCode: '1' },
-        { noteId: '2', denomCode: '2' },
-        { noteId: '3', denomCode: '3' },
-        { noteId: '4', denomCode: '4' },
-        { noteId: '5', denomCode: '5' },
-        { noteId: '6', denomCode: '6' },
-        { noteId: '7', denomCode: '7' },
-        { noteId: '8', denomCode: '3' },
-        { noteId: '9', denomCode: '4' },
-        { noteId: '10', denomCode: '5' },
-        { noteId: '11', denomCode: '6' },
-        { noteId: '12', denomCode: '7' },
-        { noteId: '13', denomCode: '3' },
-        { noteId: '14', denomCode: '4' },
-        { noteId: '15', denomCode: '5' },
-        { noteId: '16', denomCode: '6' },
-        { noteId: '17', denomCode: '7' }
-      ]
+      noteIDs: this.denomCodeSettings,
     }
   })
   .then(body => bodyOrThrow('setDenomination', body))


### PR DESCRIPTION
`initializing` and `initialized` are now common to the validator and dispenser. `disable()` calls `openCloseShutter()` only if the startup has been successful.