### PR TITLE
LAM-903 fix: mock empty/fill units

### DIFF
--- a/lib/mocks/gsr50/gsr50.js
+++ b/lib/mocks/gsr50/gsr50.js
@@ -247,6 +247,13 @@ Gsr50.prototype.refillUnit = function refillUnit () {
 }
 
 Gsr50.prototype.updateCounts = function updateCounts (newCounts) {
+  const updateClassCounts = arr =>
+    arr.map(box => {
+      const count = newCounts[box.name]
+      return count ? Object.assign(box, { count }) : box
+    })
+  this.cassettes = updateClassCounts(this.cassettes)
+  this.recyclers = updateClassCounts(this.recyclers)
 }
 
 module.exports = Gsr50


### PR DESCRIPTION
Continuation of https://github.com/lamassu/lamassu-server/pull/1728